### PR TITLE
Set CI workflow for only PR and changed test timeouts

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,11 +1,9 @@
 name: CI
 on:
-  push:
-    branches:
-      - '**'
   pull_request:
-    branches:
-      - '**'
+    types: [ready_for_review]
+      branches:
+        - '**'
   workflow_dispatch:
 permissions:
   contents: read
@@ -15,7 +13,6 @@ concurrency:
 jobs:
   unit-tests:
     name: Unit tests (Jest)
-    if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 1
     defaults:
@@ -45,7 +42,6 @@ jobs:
     name: E2E tests (Playwright)
     runs-on: ubuntu-latest
     timeout-minutes: 1
-    if: github.event_name == 'pull_request' && github.event.pull_request.draft == false
     defaults:
       run:
         working-directory: tests/e2e

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,8 +15,9 @@ concurrency:
 jobs:
   unit-tests:
     name: Unit tests (Jest)
+    if: github.event.pull_request.draft == false || github.event_name != 'pull_request'
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 1
     defaults:
       run:
         working-directory: tests/unit
@@ -43,8 +44,8 @@ jobs:
   e2e-tests:
     name: E2E tests (Playwright)
     runs-on: ubuntu-latest
-    timeout-minutes: 45
-    if: github.event_name == 'pull_request'
+    timeout-minutes: 1
+    if: github.event_name == 'pull_request' && github.event.pull_request.draft == false
     defaults:
       run:
         working-directory: tests/e2e

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,9 +1,9 @@
 name: CI
 on:
   pull_request:
-    types: [ready_for_review]
-      branches:
-        - '**'
+    types: [ready_for_review, opened, synchronize]
+    branches:
+      - '**'
   workflow_dispatch:
 permissions:
   contents: read


### PR DESCRIPTION
Reduced timouts for Jest from 15 minutes to 1
Reduced timeouts for playwright from 45 minutes to 1

Make sure only real PR's get tested, and draft PRs dont