### PR TITLE
Changed CI.yml file for workflow

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,7 +14,7 @@ jobs:
   unit-tests:
     name: Unit tests (Jest)
     runs-on: ubuntu-latest
-    timeout-minutes: 1
+    timeout-minutes: 5
     defaults:
       run:
         working-directory: tests/unit
@@ -30,7 +30,7 @@ jobs:
       - name: Install unit test dependencies
         run: npm ci
       - name: Run Jest tests
-        run: npm test -- --ci
+        run: timeout 6s npm test -- --ci
       - name: Upload unit coverage artifact
         if: always()
         uses: actions/upload-artifact@v4
@@ -41,7 +41,8 @@ jobs:
   e2e-tests:
     name: E2E tests (Playwright)
     runs-on: ubuntu-latest
-    timeout-minutes: 1
+    timeout-minutes: 8
+    if: contains(github.event.pull_request.labels.*.name, 'frontend')    
     defaults:
       run:
         working-directory: tests/e2e
@@ -54,10 +55,40 @@ jobs:
           node-version: 20
           cache: npm
           cache-dependency-path: tests/e2e/package-lock.json
+
+      - name: Log e2e npm cache status
+        run: |
+          echo "setup-node npm cache hit: ${{ steps.setup-node-e2e.outputs.cache-hit }}"
+          echo "npm cache dir: $(npm config get cache)"
+          du -sh "$(npm config get cache)" || true
+
       - name: Install e2e dependencies
         run: npm ci
+        
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('tests/e2e/package-lock.json') }}
+
+      - name: Log Playwright cache status
+        run: |
+          echo "playwright cache hit: ${{ steps.playwright-cache.outputs.cache-hit }}"
+          if [ -d ~/.cache/ms-playwright ]; then
+            du -sh ~/.cache/ms-playwright
+            ls -1 ~/.cache/ms-playwright | head -n 20
+          else
+            echo "Playwright cache directory does not exist yet"
+          fi
+
+      - name: Install Playwright system dependencies
+        run: npx playwright install-deps
+        
       - name: Install Playwright browsers
-        run: npx playwright install --with-deps
+        if: steps.playwright-cache.outputs.cache-hit  != 'true'
+        run: npx playwright install
+      
       - name: Generate and start integration stack
         working-directory: .
         run: |
@@ -83,7 +114,7 @@ jobs:
           fi
           exit 1
       - name: Run Playwright tests
-        run: npm test
+        run: timeout 6s npm test
       - name: Upload Playwright report
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,7 +1,7 @@
 name: CI
 on:
   pull_request:
-    types: [ready_for_review, opened, synchronize]
+    types: [ready_for_review, synchronize]
     branches:
       - '**'
   workflow_dispatch:


### PR DESCRIPTION
Set test timeouts to 5 minute, temporarily. This is so that it can cache the dependecies, afterwards the timeout will be set to 1 minute.
Added caching and logging to see if caching actually works
Set the github actions tests to only run on ready_for_review PRs.
Changed playwright tests to only run when PR has the frontend label.

How:
Changed variables and added logs

Why:
To not get banned again for atleast 2 days.