### PR TITLE
files for task 135 and task 138

### DIFF
--- a/drawio app/src/main/webapp/js/diagramly/EditorUi.js
+++ b/drawio app/src/main/webapp/js/diagramly/EditorUi.js
@@ -10190,13 +10190,22 @@
 				{
 					if (input.files != null)
 					{
-						// Using null for position will disable crop of input file
-						this.importFiles(input.files, null, null, this.maxImageSize);
-						
-			    		// Resets input to force change event for same file (type reset required for IE)
+						this.importFiles(input.files, null, null, this.maxImageSize, null, null, null,
+							mxUtils.bind(this, function(queue)
+							{
+								//trigger DPD validation after file import
+								if (typeof this._dpdValidate === 'function')
+								{
+									setTimeout(mxUtils.bind(this, function()
+									{
+										this._dpdValidate();
+									}), 900);  // tried out multiple time limits, this worked reasonably good
+								}
+							}));
+
 						input.type = '';
 						input.type = 'file';
-			    		input.value = '';
+						input.value = '';
 					}
 				}));
 				

--- a/drawio app/src/main/webapp/js/diagramly/Menus.js
+++ b/drawio app/src/main/webapp/js/diagramly/Menus.js
@@ -867,12 +867,12 @@
 			var filename = (currentFile != null && currentFile.getTitle() != null) ?
 				currentFile.getTitle() : editorUi.defaultFilename;
 			
-			if (!filename.endsWith('.drawio') && !filename.endsWith('.xml'))
+			// Always ensure the default filename ends with .drawio
+			if (!filename.endsWith('.drawio'))
 			{
-				filename += '.drawio';
+				filename = filename.replace(/\.[^/.]+$/, '') + '.drawio';
 			}
-			
-			var xmlContent = editorUi.getFileData(true);
+
 			var nolaiColor = '#008f89';
 
 			// Main container for dialog UI
@@ -923,9 +923,37 @@
 			// Authentication uses the active session cookie; no password required.
 			var urlInput = createField('Server URL', 'text', 'https://localhost/remote.php/dav/files/akadmin/', 'WebDAV URL');
 
-			// Ensure filename always ends with .drawio
-			if (!filename.endsWith('.drawio')) { filename += '.drawio'; }
-			var filenameInput = createField('Filename', 'text', filename, 'file.drawio');
+			var filenameInput = createField('Filename (.drawio only)', 'text', filename, 'file.drawio');
+
+			// Warning message shown when user types a wrong extension
+			var extWarning = document.createElement('div');
+			extWarning.style.cssText = [
+				'display: none',
+				'margin-top: -8px',
+				'margin-bottom: 10px',
+				'padding: 8px 12px',
+				'background: #fff3e0',
+				'border-left: 4px solid #e65100',
+				'border-radius: 0 4px 4px 0',
+				'font-size: 12px',
+				'color: #e65100',
+			].join(';');
+			extWarning.innerHTML = '&#9888; Only <strong>.drawio</strong> files are supported. The extension will be corrected automatically.';
+			div.appendChild(extWarning);
+
+			// Live enforcement: correct extension and show warning as user types
+			filenameInput.addEventListener('input', function()
+			{
+				var val = filenameInput.value;
+				if (val.includes('.') && !val.endsWith('.drawio'))
+				{
+					extWarning.style.display = 'block';
+				}
+				else
+				{
+					extWarning.style.display = 'none';
+				}
+			});
 
 			// Dialog logic
 			var dlg = new CustomDialog(editorUi, div, function()
@@ -933,8 +961,14 @@
 				var url = urlInput.value.trim();
 
 				var fname = filenameInput.value.trim();
-				// Force .drawio extension
-				if (!fname.endsWith('.drawio')) { fname += '.drawio'; }
+				// Strip any extension and enforce .drawio before saving
+				if (!fname.endsWith('.drawio'))
+				{
+					fname = fname.replace(/\.[^/.]+$/, '').replace(/\.$/, '') + '.drawio';
+				}
+
+				// Capture XML at confirm time so all model changes are included
+				var xmlContent = editorUi.getFileData(true);
 
 				if (typeof saveDrawIOToNextcloudXML === 'function')
 				{
@@ -1109,6 +1143,15 @@
 									editorUi.fileLoaded(new LocalFile(editorUi, xml, selected.name, true), true);
 									editorUi.editor.modified = false;
 									editorUi.editor.setStatus('Loaded from Nextcloud successfully');
+
+									// Re-run DPD validation after model has fully settled
+									setTimeout(function()
+									{
+										if (typeof editorUi._dpdValidate === 'function')
+										{
+											editorUi._dpdValidate();
+										}
+									}, 900);
 								}
 								catch (e)
 								{
@@ -5694,7 +5737,7 @@
 
 				if (urlParams['noDevice'] != '1')
 				{
-					menu.addItem(mxResources.get('device') + '...', null, function()
+					menu.addItem(mxResources.get('importFrom') + ' ' + mxResources.get('device') + '...', null, function()
 					{
 						editorUi.importLocalFile(true);
 					}, parent);

--- a/drawio app/src/main/webapp/plugins/dpd.js
+++ b/drawio app/src/main/webapp/plugins/dpd.js
@@ -218,7 +218,7 @@ Draw.loadPlugin(function (ui) {
           sourceType: st,
           targetType: tt,
         });
-        return false;
+        return true;
       }
 
       if (st === 'external_entity' && tt === 'external_entity') {
@@ -226,7 +226,7 @@ Draw.loadPlugin(function (ui) {
           sourceType: st,
           targetType: tt,
         });
-        return false;
+        return true;
       }
 
       if (
@@ -237,7 +237,7 @@ Draw.loadPlugin(function (ui) {
           sourceType: st,
           targetType: tt,
         });
-        return false;
+        return true;
       }
     }
 

--- a/tests/unit/dpd.plugin.test.js
+++ b/tests/unit/dpd.plugin.test.js
@@ -262,47 +262,47 @@ describe('Console violation helpers', () => {
 // is drawn. The connection is rejected and a violation is logged to the console.
 // ---------------------------------------------------------------------------
 
-describe('Structural connection blocking (R-S1, R-S2, R-S3)', () => {
+describe('Structural connection violations (R-S1, R-S2, R-S3)', () => {
   beforeEach(() => { jest.useFakeTimers(); global.alert.mockClear(); });
   afterEach(() => { jest.runOnlyPendingTimers(); jest.useRealTimers(); });
 
-  it('rejects data_store → data_store and reports R-S1', () => {
+  it('allows data_store → data_store but reports R-S1 violation', () => {
     const { graph, dpdConsole } = loadSemanticPlugin();
     const result = graph.isValidConnection(
       makeSemanticNode({ id: 1, type: 'data_store' }),
       makeSemanticNode({ id: 2, type: 'data_store' }),
     );
-    expect(result).toBe(false);
+    expect(result).toBe(true);
     expect(dpdConsole.addViolation).toHaveBeenCalledWith('R-S1', expect.any(String), 'error', expect.any(Object));
   });
 
-  it('rejects external_entity → external_entity and reports R-S2', () => {
+  it('allows external_entity → external_entity but reports R-S2 violation', () => {
     const { graph, dpdConsole } = loadSemanticPlugin();
     const result = graph.isValidConnection(
       makeSemanticNode({ id: 10, type: 'external_entity' }),
       makeSemanticNode({ id: 11, type: 'external_entity' }),
     );
-    expect(result).toBe(false);
+    expect(result).toBe(true);
     expect(dpdConsole.addViolation).toHaveBeenCalledWith('R-S2', expect.any(String), 'error', expect.any(Object));
   });
 
-  it('rejects data_store → external_entity and reports R-S3', () => {
+  it('allows data_store → external_entity but reports R-S3 violation', () => {
     const { graph, dpdConsole } = loadSemanticPlugin();
     const result = graph.isValidConnection(
       makeSemanticNode({ id: 12, type: 'data_store' }),
       makeSemanticNode({ id: 13, type: 'external_entity' }),
     );
-    expect(result).toBe(false);
+    expect(result).toBe(true);
     expect(dpdConsole.addViolation).toHaveBeenCalledWith('R-S3', expect.any(String), 'error', expect.any(Object));
   });
 
-  it('rejects external_entity → data_store (R-S3 applies in both directions)', () => {
+  it('allows external_entity → data_store but reports R-S3 violation (applies in both directions)', () => {
     const { graph, dpdConsole } = loadSemanticPlugin();
     const result = graph.isValidConnection(
       makeSemanticNode({ id: 14, type: 'external_entity' }),
       makeSemanticNode({ id: 15, type: 'data_store' }),
     );
-    expect(result).toBe(false);
+    expect(result).toBe(true);
     expect(dpdConsole.addViolation).toHaveBeenCalledWith('R-S3', expect.any(String), 'error', expect.any(Object));
   });
 


### PR DESCRIPTION
What:
- fixed storage to storage blocking
- Added drawio extension enforcement
- Added loading a file from local device

How:
- Change the rule enforcement (booleans) to allow a connection with an error
- Change the way that the filename is accepted
- Re-enabled the load from deviced button and run validate rules function whenever file is loaded.

Why:
- so an connection is possible.
- so any file always have the .drawio extension so that it can be found in the Nextcloud server
