### PR TITLE
edit properies task #134

### DIFF
--- a/drawio app/src/main/webapp/plugins/dpd.js
+++ b/drawio app/src/main/webapp/plugins/dpd.js
@@ -1259,14 +1259,26 @@ Draw.loadPlugin(function (ui) {
 
   // Right-click popup menu extension
 
+  // ====== NOLAI - {Frontend} /Sprint 3/ Task #134 ======
   const origPopup = graph.popupMenuHandler.factoryMethod.bind(graph.popupMenuHandler);
   graph.popupMenuHandler.factoryMethod = function (menu, cell, evt) {
     if (cell && model.isEdge(cell)) {
       menu.addItem('Annotate Data Flow…', null, () => showEdgeAnnotationDialog(cell), null, null, true);
       menu.addSeparator();
     }
+    if (cell && model.isVertex(cell)) {
+      const nodeType = getComponentType(cell);
+      if (nodeType === 'process') {
+        menu.addItem('Edit Properties…', null, () => showProcessAnnotationDialog(cell), null, null, true);
+        menu.addSeparator();
+      } else if (nodeType === 'data_store') {
+        menu.addItem('Edit Properties…', null, () => showDataAnnotationDialog(cell), null, null, true);
+        menu.addSeparator();
+      }
+    }
     return origPopup(menu, cell, evt);
   };
+  // ====== end of changes by SE ======
 
   console.log('DPD Plugin Loaded');
   console.log('[DPD] Plugin loaded — 15 rules active (R-S1–4, R-I1–5, R-L1–2, R-P1–4)');


### PR DESCRIPTION
WHAT:
added option for editing properties according to task #134 

HOW:
right clicking it opens the same annotation dialog that appears on first drop:          
  - Process → opens showProcessAnnotationDialog (accepts/outputs max identifiability, accepts max linkability)          
  - Data store → opens showDataAnnotationDialog (stores max identifiability)                                            
  - External entity — no DPD attributes, no menu item added                                                             
  - Edge — unchanged, still shows "Annotate Data Flow…" as before  

WHY:
Users need to be able to change properties of already created objects