### PR TITLE
Version Control UI & ctrl + s & rename fix (Tasks: 152, 107, 157, 149, 152) 

### DIFF
--- a/drawio app/src/main/webapp/js/diagramly/Menus.js
+++ b/drawio app/src/main/webapp/js/diagramly/Menus.js
@@ -859,20 +859,162 @@
 		*/
 		// ======	NOLAI - {- Backend -} /Sprint 1/ Task 16	=====
 		// ======   NOLAI - {- Frontend -} /Sprint 2/ Task 98   =====
+		// ======   NOLAI - {- Backend / Frontend -} /Sprint 4/ Task 148 — Smart Save / Save As / ⌘+S =====
+		//
+		// SAVE / SAVE AS — professional-app behaviour.
+		//
+		// Two actions are registered:
+		//   'Save'     — quick path: PUTs the current XML straight back to the
+		//                Nextcloud file the editor is currently bound to (recorded
+		//                in _nolaiCurrentNextcloudFile). Falls through to the Save
+		//                As dialog when there's no bound file yet (first save) or
+		//                when no Nextcloud session is available.
+		//   'Save As'  — always opens the dialog so the user can pick / change
+		//                the filename. Useful for first-time saves or "save a copy".
+		//
+		// Both actions converge on finalizeSaveSuccess() once the WebDAV PUT
+		// returns 2xx — that helper handles every UI side-effect a "real" save
+		// triggers in a desktop app:
+		//   1. Update the in-memory LocalFile.title so any later rename or save
+		//      uses the new filename as the source.
+		//   2. Update the title bar via updateNolaiFileTitle.
+		//   3. Record the binding in _nolaiCurrentNextcloudFile so future
+		//      ⌘+S calls hit the quick path.
+		//   4. Clear editorUi.editor.modified so drawio's "unsaved changes"
+		//      affordance (titlebar asterisk, beforeunload warning) clears.
+		//   5. Show a status line.
+		//
+		// WHY one helper rather than duplicating the success block:
+		//   The two save flows have to do exactly the same work on success;
+		//   keeping the code in one place removes the risk of drift (e.g. one
+		//   path forgets to clear modified and ⌘+S keeps re-prompting).
+		// ====== end of changes by SE ======
 
-		editorUi.actions.addAction('Save', function()
+		// nolaiNextcloudBaseUrl — the Nextcloud root that all save/load WebDAV
+		// calls in this file build URLs against. Centralised so the constant
+		// only appears once and the multiple actions below stay aligned.
+		var nolaiNextcloudBaseUrl = 'https://localhost';
+
+		// finalizeSaveSuccess — single source of truth for what "save was
+		// successful" means in UI terms. Called by both the quick save path
+		// and the Save As dialog when the WebDAV PUT returns 2xx.
+		function finalizeSaveSuccess(fname, remotePath)
+		{
+			// Update the in-memory LocalFile so subsequent rename / save uses
+			// the saved filename as the source. Setting `title` directly
+			// rather than calling rename() to avoid recursing into our rename
+			// override, which would attempt another WebDAV operation.
+			var current = editorUi.getCurrentFile();
+			if (current != null) { current.title = fname; }
+
+			// Record the binding so the next ⌘+S goes straight to a silent PUT.
+			if (typeof nolaiSetCurrentNextcloudFile === 'function')
+			{
+				nolaiSetCurrentNextcloudFile(fname, remotePath || '/');
+			}
+
+			// Update the toolbar filename and document title.
+			if (typeof updateNolaiFileTitle === 'function') { updateNolaiFileTitle(fname); }
+
+			// Clear the modified flag so drawio stops flagging the file as
+			// dirty (titlebar asterisk, beforeunload, etc.).
+			editorUi.editor.modified = false;
+			if (current != null && typeof current.setModified === 'function')
+			{
+				try { current.setModified(false); } catch (e) { /* not all file types support this */ }
+			}
+
+			editorUi.editor.setStatus('Saved to Nextcloud — ' + fname);
+		}
+
+		// quickSaveCurrentFile — synchronous attempt at a no-dialog save. Returns
+		// true if the save was started (caller should not open a dialog), false
+		// if the preconditions weren't met (caller should open Save As).
+		//
+		// Preconditions: a tracked Nextcloud file AND a cached signed-in session.
+		// If either is missing, we cannot do a silent save without surprising
+		// the user, so we return false and let the dialog flow take over.
+		function quickSaveCurrentFile()
+		{
+			if (typeof saveDrawIOToNextcloudXML !== 'function') { return false; }
+			if (typeof nolaiGetCurrentNextcloudFile !== 'function') { return false; }
+
+			var bound = nolaiGetCurrentNextcloudFile();
+			var session = (typeof _nextcloudSessionCache !== 'undefined') ? _nextcloudSessionCache : null;
+
+			if (!bound || !session || !session.username || !session.password)
+			{
+				return false;
+			}
+
+			// ====== NOLAI - {- Backend -} /Sprint 4/ Task 148 — staleness guard ======
+			// If the editor's current LocalFile no longer matches what the tracker
+			// thinks we're bound to (e.g. the user clicked File → New and is now
+			// editing a fresh untitled document), the binding is stale and a
+			// silent PUT would overwrite the wrong Nextcloud file. In that case
+			// drop the binding and force the caller into the Save As dialog.
+			//
+			// Title equality is sufficient because every place that updates the
+			// tracker also updates currentFile.title to the same value.
+			// ====== end of changes by SE ======
+			var current = editorUi.getCurrentFile();
+			var currentTitle = (current != null && typeof current.getTitle === 'function')
+				? current.getTitle() : null;
+			if (currentTitle !== bound.filename)
+			{
+				if (typeof nolaiClearCurrentNextcloudFile === 'function') { nolaiClearCurrentNextcloudFile(); }
+				return false;
+			}
+
+			var fname = bound.filename;
+			var remotePath = bound.remotePath || '/';
+			var xmlContent = editorUi.getFileData(true);
+			var url = nolaiNextcloudBaseUrl + '/remote.php/dav/files/' + encodeURIComponent(session.username) + '/';
+
+			editorUi.spinner.spin(document.body, 'Saving…');
+
+			saveDrawIOToNextcloudXML(fname, xmlContent, url, session.username, session.password, remotePath)
+				.then(function(ok)
+				{
+					editorUi.spinner.stop();
+					if (ok)
+					{
+						finalizeSaveSuccess(fname, remotePath);
+					}
+					else
+					{
+						// Quick save failed — the file may have been deleted or
+						// renamed on the server. Drop the binding and let the
+						// next action open the Save As dialog so the user can
+						// pick a new name.
+						if (typeof nolaiClearCurrentNextcloudFile === 'function') { nolaiClearCurrentNextcloudFile(); }
+						editorUi.handleError({message: 'Save failed. The file may have been moved or deleted on Nextcloud — please use Save As.'});
+					}
+				})
+				.catch(function(err)
+				{
+					editorUi.spinner.stop();
+					editorUi.handleError({message: 'Save error: ' + err.message});
+				});
+
+			return true;
+		}
+
+		// openSaveAsDialog — the existing professional Save dialog, extracted
+		// so both 'Save' (when there's no bound file) and 'Save As' can reuse it.
+		// On success it converges on finalizeSaveSuccess just like the quick path.
+		function openSaveAsDialog()
 		{
 			// Get filename and ensure that it is a valid file
 			var currentFile = editorUi.getCurrentFile();
 			var filename = (currentFile != null && currentFile.getTitle() != null) ?
 				currentFile.getTitle() : editorUi.defaultFilename;
-			
+
 			if (!filename.endsWith('.drawio') && !filename.endsWith('.xml'))
 			{
 				filename += '.drawio';
 			}
-			
-			var xmlContent = editorUi.getFileData(true);
+
 			var nolaiColor = '#008f89';
 
 			// Main container for dialog UI
@@ -887,7 +1029,7 @@
 
 			// ====== NOLAI - {- Backend -} /Sprint 3/ Task 151 ======
 			// Nextcloud base URL — WebDAV paths are built from this + the uid returned by the banner.
-			var nextcloudBaseUrl = 'https://localhost';
+			var nextcloudBaseUrl = nolaiNextcloudBaseUrl;
 			var nextcloudUsername = null; // uid, populated by the session banner on connect
 			var nextcloudPassword = null; // app password for WebDAV Basic Auth, also from banner
 
@@ -993,45 +1135,112 @@
 				var fname = baseVal + '.drawio';
 				// ====== end of changes by SE ======
 
-				if (typeof saveDrawIOToNextcloudXML === 'function')
-				{
-					editorUi.spinner.spin(document.body, 'Saving to Nextcloud...');
-
-					// App password used for Basic Auth; session cookie deliberately omitted (see buildNextcloudWebdavBaseContext).
-					saveDrawIOToNextcloudXML(fname, xmlContent, url, null, nextcloudPassword, '/').then(function(success)
-					{
-						editorUi.spinner.stop();
-						if (success)
-						{
-							editorUi.editor.setStatus('Saved to Nextcloud successfully');
-							// Update the title bar overlay to reflect the saved filename.
-							if (typeof updateNolaiFileTitle === 'function') { updateNolaiFileTitle(fname); }
-						}
-						else
-						{
-							editorUi.handleError({message: 'Failed to save to Nextcloud. Check console for details.'});
-						}
-					}).catch(function(error)
-					{
-						editorUi.spinner.stop();
-						editorUi.handleError({message: 'Error: ' + error.message});
-					});
-				}
-				else
+				if (typeof saveDrawIOToNextcloudXML !== 'function')
 				{
 					editorUi.handleError({message: 'NextcloudFile.js is not loaded'});
+					return;
 				}
+
+				editorUi.spinner.spin(document.body, 'Saving to Nextcloud...');
+
+				// Take the editor XML at SAVE TIME (not dialog-open time) so any
+				// edits the user made while the dialog was open are persisted.
+				var xmlContent = editorUi.getFileData(true);
+
+				// App password used for Basic Auth; session cookie deliberately omitted (see buildNextcloudWebdavBaseContext).
+				saveDrawIOToNextcloudXML(fname, xmlContent, url, nextcloudUsername, nextcloudPassword, '/').then(function(ok)
+				{
+					editorUi.spinner.stop();
+					if (ok)
+					{
+						// Converge on the same success-side-effects as quickSaveCurrentFile.
+						finalizeSaveSuccess(fname, '/');
+					}
+					else
+					{
+						editorUi.handleError({message: 'Failed to save to Nextcloud. Check console for details.'});
+					}
+				}).catch(function(error)
+				{
+					editorUi.spinner.stop();
+					editorUi.handleError({message: 'Error: ' + error.message});
+				});
 			});
 
 			// Styling the OK button for saving files.
 			dlg.okButton.innerHTML = 'Save Diagram';
-    		dlg.okButton.style.backgroundColor = nolaiColor;
+			dlg.okButton.style.backgroundColor = nolaiColor;
 			dlg.okButton.style.backgroundImage = 'none';
 			dlg.okButton.style.color = '#fff';
 
 			editorUi.showDialog(dlg.container, 450, 280, true, true);
 			filenameInput.focus();
+		}
+
+		// 'Save' — quick save when possible, dialog when not. Hooked to ⌘+S
+		// further below by overriding the createRevision action's funct.
+		editorUi.actions.addAction('Save', function()
+		{
+			if (!quickSaveCurrentFile())
+			{
+				openSaveAsDialog();
+			}
 		});
+
+		// 'Save As' — always opens the dialog. Useful for first-time saves and
+		// for saving a copy under a new name without breaking the binding for
+		// the original (we deliberately update the binding to the new name on
+		// success — matching desktop apps where Save As re-binds the editor
+		// to the just-created file).
+		editorUi.actions.addAction('Save As', function()
+		{
+			openSaveAsDialog();
+		});
+
+		// ====== NOLAI - {- Frontend -} /Sprint 4/ Task 148 — keyboard shortcut & built-in save routing ======
+		//
+		// drawio's keyboard handler in js/grapheditor/EditorUi.js (line ~6464)
+		// binds Ctrl/⌘+S directly to the lowercase 'save' action, and ⌘+Shift+S
+		// to 'saveAs'. Those built-in actions, when triggered against a LocalFile
+		// or in the standalone editor, open drawio's native "Save as" dialog —
+		// the one with Google Drive / OneDrive / Dropbox in the "Where:" dropdown.
+		// In our deployment that's wrong: the only sanctioned remote storage is
+		// Nextcloud, and we already have a dedicated Save dialog for it.
+		//
+		// We replace the funct on those built-in Action objects so EVERY path
+		// that ends up calling them — keyboard shortcuts, theme menus, internal
+		// drawio code that invokes editorUi.actions.get('save').funct() — routes
+		// into our Nextcloud Save / Save As flow instead. This is safe because
+		// bindAction's closure reads action.funct at invocation time (see
+		// keyHandler.bindAction in grapheditor/EditorUi.js), so the binding
+		// established at startup picks up our override automatically.
+		//
+		// We also override 'createRevision' for completeness — it has the same
+		// keyboard hint metadata and some themes display it as a separate menu
+		// item that delegates to 'save'.
+		//
+		// Local-disk download remains accessible through File → Export → XML
+		// (drawio's separate 'export' action, which we deliberately leave
+		// untouched). Cloud storage providers other than Nextcloud are no
+		// longer reachable via Save / Save As.
+		// ====== end of changes by SE ======
+		(function() {
+			// Helper: replace an action's funct if the action exists. Logging on
+			// success makes it obvious in the console which built-in actions were
+			// successfully captured at startup.
+			function redirectAction(actionName, target)
+			{
+				var a = editorUi.actions.get(actionName);
+				if (a)
+				{
+					a.funct = function() { editorUi.actions.get(target).funct(); };
+				}
+			}
+
+			redirectAction('save',           'Save');     // Ctrl+S        → smart Save
+			redirectAction('saveAs',         'Save As');  // Ctrl+Shift+S  → Save As dialog
+			redirectAction('createRevision', 'Save');     // legacy menu item → smart Save
+		})();
 	
 		// ======	NOLAI - {- Backend -} /Sprint 1/ Task 92	=====
 		// ======   NOLAI - {- Frontend -} /Sprint 2/ Task 100  =====
@@ -1135,6 +1344,14 @@
 									editorUi.editor.setStatus('Loaded from Nextcloud successfully');
 									// Update the title bar overlay to reflect the loaded filename.
 									if (typeof updateNolaiFileTitle === 'function') { updateNolaiFileTitle(selected.name); }
+									// ====== NOLAI - {- Backend -} /Sprint 4/ Task 148 — bind editor to Nextcloud file ======
+									// Record which Nextcloud file the editor is now editing, so the next
+									// ⌘+S quick-saves to the same path instead of re-prompting.
+									// ====== end of changes by SE ======
+									if (typeof nolaiSetCurrentNextcloudFile === 'function')
+									{
+										nolaiSetCurrentNextcloudFile(selected.name, selected.remotePath || '/');
+									}
 								}
 								catch (e)
 								{
@@ -1287,6 +1504,493 @@
 				// session banner callback once the user authenticates.
 				loginDlg.okButton.style.display = 'none';
 
+				editorUi.showDialog(loginDlg.container, 450, 240, true, true);
+			}
+		});
+
+		// ====== end of changes by SE	======
+
+		// ======	NOLAI - {- Backend -} /Sprint 4/ Task 148 (Version Control)	=====
+		// ======   NOLAI - {- Frontend -} /Sprint 4/ Task 148 (Version Control)   =====
+		//
+		// 'Version History' action — opens an in-app version-control UI that lists
+		// every server-side version of the currently open .drawio file, lets the
+		// user preview any version on a read-only Graph, and atomically rolls the
+		// live file back to a chosen version via WebDAV MOVE to the Nextcloud
+		// /restore/target marker.
+		//
+		// WHY a custom dialog (and not draw.io's built-in RevisionDialog):
+		//   The native dialog is wired to ui.getRevisions(), which plugins/nextcloud.js
+		//   implements via remoteInvoke('getFileRevisions') — a postMessage RPC that
+		//   only works when drawio is embedded inside Nextcloud's parent window. In
+		//   our standalone NOLAI deployment drawio is a separate origin, so the
+		//   postMessage path has no listener and the native dialog never resolves.
+		//   This action calls the Nextcloud Versions WebDAV endpoint directly using
+		//   the same auth path as Save / My Files / rename, so it works without any
+		//   embedding. The native action is intentionally left untouched so that
+		//   future embedded usage (if drawio is ever loaded inside Nextcloud's iframe
+		//   integration) keeps working without a code change.
+		//
+		// Assumptions:
+		//   - The file lives at the user's DAV root ('/'). This matches the rename
+		//     override and the Save dialog defaults; subfolder support would require
+		//     tracking remotePath on LocalFile during load and is a known follow-up.
+		//   - The user is signed in to Nextcloud via the existing session banner /
+		//     top-bar chip (cached in _nextcloudSessionCache). If not, the dialog
+		//     embeds the same session banner used elsewhere so the user can sign in
+		//     without leaving Version History.
+		//   - The current file has been saved at least once (otherwise no fileid /
+		//     no versions exist) — this is detected by a PROPFIND for fileid and
+		//     the user is shown a "Save first" message with a shortcut button.
+		// ====== end of changes by SE ======
+		editorUi.actions.addAction('Version History', function()
+		{
+			var nolaiColor = '#008f89';
+			var nextcloudBaseUrl = 'https://localhost';
+			var nextcloudUsername = null;
+			var nextcloudPassword = null;
+
+			// Guard: every helper used here is defined in NextcloudFile.js. If the
+			// script failed to load we surface an immediate error rather than a
+			// confusing "x is not a function" trace later in the flow.
+			if (typeof getFileIdFromNextcloud !== 'function' ||
+				typeof listFileVersionsInNextcloud !== 'function' ||
+				typeof getVersionContentFromNextcloud !== 'function' ||
+				typeof restoreVersionInNextcloud !== 'function')
+			{
+				editorUi.handleError({message: 'Version control helpers are not loaded (NextcloudFile.js).'});
+				return;
+			}
+
+			// formatRelative — renders ms-since-epoch as "5 minutes ago" / "2 days ago".
+			// WHY a tiny inline implementation rather than a date library: draw.io
+			// already ships with no date library and adding one for one widget is
+			// disproportionate; this covers the four buckets users actually scan for.
+			function formatRelative(ms)
+			{
+				if (!ms) { return ''; }
+				var diff = Math.max(0, Date.now() - ms);
+				var s = Math.floor(diff / 1000);
+				if (s < 60)    { return 'just now'; }
+				var m = Math.floor(s / 60);
+				if (m < 60)    { return m + (m === 1 ? ' minute ago' : ' minutes ago'); }
+				var h = Math.floor(m / 60);
+				if (h < 24)    { return h + (h === 1 ? ' hour ago'   : ' hours ago'); }
+				var d = Math.floor(h / 24);
+				if (d < 30)    { return d + (d === 1 ? ' day ago'    : ' days ago'); }
+				var mo = Math.floor(d / 30);
+				if (mo < 12)   { return mo + (mo === 1 ? ' month ago' : ' months ago'); }
+				var y = Math.floor(d / 365);
+				return y + (y === 1 ? ' year ago' : ' years ago');
+			}
+
+			// formatBytes — converts a byte count to a short "12.3 KB" string.
+			function formatBytes(b)
+			{
+				if (b == null) { return ''; }
+				if (b < 1024)               { return b + ' B'; }
+				if (b < 1024 * 1024)        { return (b / 1024).toFixed(1) + ' KB'; }
+				return (b / (1024 * 1024)).toFixed(1) + ' MB';
+			}
+
+			// showSaveFirst — replaces the dialog body with a friendly "save first"
+			// message + a button that triggers the existing Save action. This is
+			// shown when the file is untitled or has no fileid on the server.
+			function showSaveFirst(container, reasonText)
+			{
+				container.innerHTML = '';
+
+				var title = document.createElement('h2');
+				title.innerHTML = 'Version History';
+				title.style.cssText = 'margin: 0 0 15px 0; color: ' + nolaiColor + '; font-size: 18px; border-bottom: 2px solid ' + nolaiColor + '; padding-bottom: 10px;';
+				container.appendChild(title);
+
+				var msg = document.createElement('div');
+				msg.style.cssText = 'padding: 16px; background: #fff8e1; border: 1px solid #ffb300; border-radius: 6px; color: #5d4037; font-size: 13px; line-height: 1.5;';
+				msg.innerHTML = (reasonText ||
+					'This diagram has not yet been saved to Nextcloud, so no versions exist.') +
+					'<br><br>Save the diagram to Nextcloud first — Nextcloud automatically captures a new version every time you save.';
+				container.appendChild(msg);
+
+				var btnRow = document.createElement('div');
+				btnRow.style.cssText = 'display: flex; justify-content: flex-end; margin-top: 16px;';
+
+				var saveBtn = document.createElement('button');
+				saveBtn.innerHTML = 'Save to Nextcloud…';
+				saveBtn.style.cssText = 'padding: 8px 16px; border: none; border-radius: 4px; background: ' + nolaiColor + '; color: #fff; cursor: pointer; font-weight: 600;';
+				saveBtn.onclick = function()
+				{
+					editorUi.hideDialog();
+					editorUi.actions.get('Save').funct();
+				};
+				btnRow.appendChild(saveBtn);
+				container.appendChild(btnRow);
+			}
+
+			// renderVersionList — once we have credentials AND a confirmed fileid,
+			// this builds the actual two-pane Version History UI.
+			//
+			// Layout (700×460):
+			//   Header row     — title + session banner (gives the user a way to
+			//                    re-authenticate without closing the dialog if their
+			//                    app password is rejected mid-session).
+			//   Filename strip — small caption above the list, so the user always
+			//                    knows which file they are viewing versions of.
+			//   Body grid      — left: 220px scrollable version list
+			//                    right: ~430px live preview pane with a read-only
+			//                           Graph (matches the native RevisionDialog style).
+			//   Footer row     — error/status line + Restore + Close buttons.
+			function renderVersionList(container, filename, fileId, versions)
+			{
+				container.innerHTML = '';
+				container.style.fontFamily = 'Helvetica, Arial, sans-serif';
+
+				var title = document.createElement('h2');
+				title.innerHTML = 'Version History';
+				title.style.cssText = 'margin: 0 0 8px 0; color: ' + nolaiColor + '; font-size: 18px; border-bottom: 2px solid ' + nolaiColor + '; padding-bottom: 8px;';
+				container.appendChild(title);
+
+				// Filename caption: ellipsis on overflow so very long names do not
+				// break the layout.
+				var fileLine = document.createElement('div');
+				fileLine.style.cssText = 'color:#555; font-size:12px; margin: 0 0 12px 0; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;';
+				fileLine.innerHTML = '<strong>File:</strong> ' + filename;
+				container.appendChild(fileLine);
+
+				if (!versions || versions.length === 0)
+				{
+					var empty = document.createElement('div');
+					empty.style.cssText = 'padding: 16px; background: #f5f5f5; border-radius: 6px; color: #555; font-size: 13px;';
+					empty.innerHTML =
+						'No prior versions yet.<br><br>' +
+						'Nextcloud only starts keeping versions <em>after</em> the first re-save. ' +
+						'Save the file again to create the first historical version.';
+					container.appendChild(empty);
+					return;
+				}
+
+				// Two-pane body grid.
+				var body = document.createElement('div');
+				body.style.cssText = 'display: grid; grid-template-columns: 220px 1fr; gap: 12px; height: 320px;';
+				container.appendChild(body);
+
+				// ---- Left: version list ----
+				// Plain styled buttons rather than a <select> so we can show
+				// multi-line entries (timestamp + relative time + size) cleanly.
+				var listWrap = document.createElement('div');
+				listWrap.style.cssText = 'border: 1px solid #ddd; border-radius: 6px; overflow-y: auto; background: #fafafa;';
+				body.appendChild(listWrap);
+
+				// ---- Right: preview pane ----
+				var previewWrap = document.createElement('div');
+				previewWrap.style.cssText = 'border: 1px solid #ddd; border-radius: 6px; position: relative; overflow: hidden; background: #fff;';
+				body.appendChild(previewWrap);
+
+				var previewStatus = document.createElement('div');
+				previewStatus.style.cssText = 'position: absolute; left: 50%; top: 50%; transform: translate(-50%, -50%); color: #888; font-size: 12px; pointer-events: none;';
+				previewStatus.innerText = 'Select a version to preview';
+				previewWrap.appendChild(previewStatus);
+
+				// Read-only preview Graph. We use the same approach as the native
+				// RevisionDialog (Dialogs.js): instantiate a Graph, disable input,
+				// then decode the version XML into its model. Pan + scroll is kept
+				// on so users can move around large diagrams.
+				var previewGraph = new Graph(previewWrap);
+				previewGraph.setTooltips(false);
+				previewGraph.setEnabled(false);
+				previewGraph.setPanning(true);
+				previewGraph.panningHandler.ignoreCell = true;
+				previewGraph.panningHandler.useLeftButtonForPanning = true;
+
+				// ---- Footer: status line + buttons ----
+				var footer = document.createElement('div');
+				footer.style.cssText = 'display: flex; align-items: center; gap: 8px; margin-top: 14px;';
+				container.appendChild(footer);
+
+				var status = document.createElement('span');
+				status.style.cssText = 'flex: 1; color: #666; font-size: 12px; min-height: 16px;';
+				footer.appendChild(status);
+
+				var closeBtn = document.createElement('button');
+				closeBtn.innerHTML = 'Close';
+				closeBtn.style.cssText = 'padding: 7px 14px; border: 1px solid #ccc; border-radius: 4px; background: #fff; color: #333; cursor: pointer;';
+				closeBtn.onclick = function() { editorUi.hideDialog(); };
+				footer.appendChild(closeBtn);
+
+				var restoreBtn = document.createElement('button');
+				restoreBtn.innerHTML = 'Restore this version';
+				restoreBtn.disabled = true;
+				restoreBtn.style.cssText = 'padding: 7px 14px; border: none; border-radius: 4px; background: ' + nolaiColor + '; color: #fff; cursor: pointer; font-weight: 600; opacity: 0.5;';
+				footer.appendChild(restoreBtn);
+
+				// selectedVersion — the entry currently shown in the preview pane,
+				// also the version that the Restore button will act on.
+				var selectedVersion = null;
+				var selectedRow = null;
+
+				// applyXmlToPreview — decodes XML into the preview Graph. We pull
+				// the first <diagram> element out of an <mxfile>; that's how
+				// drawio's RevisionDialog renders previews. If the XML is just an
+				// <mxGraphModel> (older format) we pass it through directly.
+				function applyXmlToPreview(xml)
+				{
+					try
+					{
+						var doc = mxUtils.parseXml(xml);
+						var node = doc.documentElement;
+						if (node.nodeName === 'mxfile')
+						{
+							var diagram = node.getElementsByTagName('diagram')[0];
+							if (diagram)
+							{
+								node = Editor.parseDiagramNode(diagram);
+							}
+						}
+						var codec = new mxCodec(node.ownerDocument);
+						previewGraph.getModel().clear();
+						codec.decode(node, previewGraph.getModel());
+						previewGraph.maxFitScale = 1;
+						previewGraph.fit(8);
+						previewGraph.center();
+						previewStatus.style.display = 'none';
+					}
+					catch (e)
+					{
+						previewStatus.style.display = '';
+						previewStatus.innerText = 'Could not render preview: ' + e.message;
+					}
+				}
+
+				// selectVersion — visually marks the row, fetches the XML, renders.
+				function selectVersion(version, rowEl)
+				{
+					if (selectedRow) { selectedRow.style.background = ''; selectedRow.style.color = ''; }
+					selectedRow = rowEl;
+					selectedVersion = version;
+					rowEl.style.background = nolaiColor;
+					rowEl.style.color = '#fff';
+
+					restoreBtn.disabled = false;
+					restoreBtn.style.opacity = '1';
+
+					previewStatus.style.display = '';
+					previewStatus.innerText = 'Loading preview…';
+					status.innerText = '';
+
+					getVersionContentFromNextcloud(version.absUrl, nextcloudBaseUrl, nextcloudUsername, nextcloudPassword)
+						.then(function(xml)
+						{
+							if (!xml) { throw new Error('empty response'); }
+							applyXmlToPreview(xml);
+						})
+						.catch(function(err)
+						{
+							previewStatus.style.display = '';
+							previewStatus.innerText = 'Preview failed: ' + err.message;
+						});
+				}
+
+				// Build version rows. The most recent version is selected by default
+				// so users see something useful immediately on dialog open.
+				versions.forEach(function(v, idx)
+				{
+					var row = document.createElement('div');
+					row.style.cssText = 'padding: 8px 10px; border-bottom: 1px solid #eee; cursor: pointer; font-size: 12px; line-height: 1.35; transition: background 0.1s;';
+
+					var dateStr = v.mtime ? new Date(v.mtime).toLocaleString() : '(unknown date)';
+					var rel = formatRelative(v.mtime);
+					var sizeStr = formatBytes(v.size);
+
+					row.innerHTML =
+						'<div style="font-weight:600;">' + dateStr + '</div>' +
+						'<div style="opacity:0.85;">' + rel + (sizeStr ? ' &middot; ' + sizeStr : '') + '</div>';
+
+					row.onmouseover = function()
+					{
+						if (row !== selectedRow) { row.style.background = '#eef7f7'; }
+					};
+					row.onmouseout = function()
+					{
+						if (row !== selectedRow) { row.style.background = ''; }
+					};
+					row.onclick = function() { selectVersion(v, row); };
+
+					listWrap.appendChild(row);
+
+					// Auto-select the newest entry (top of the list).
+					if (idx === 0) { setTimeout(function() { selectVersion(v, row); }, 0); }
+				});
+
+				// ---- Restore handler ----
+				// Two-step: confirm dialog, then MOVE, then reload the live file
+				// from Nextcloud so the editor reflects the restored content.
+				restoreBtn.onclick = function()
+				{
+					if (!selectedVersion) { return; }
+
+					var when = selectedVersion.mtime ? new Date(selectedVersion.mtime).toLocaleString() : 'this version';
+					editorUi.confirm(
+						'Restore the version from ' + when + '?\n\n' +
+						'The current diagram will be replaced. The version you are replacing will itself be saved as a new historical entry, so this action is reversible.',
+						null,
+						function()
+						{
+							restoreBtn.disabled = true;
+							restoreBtn.style.opacity = '0.5';
+							status.innerText = 'Restoring…';
+
+							restoreVersionInNextcloud(selectedVersion.absUrl, nextcloudBaseUrl, nextcloudUsername, nextcloudPassword)
+								.then(function()
+								{
+									// After the server has restored, pull the live file
+									// fresh so the editor canvas reflects the rolled-back
+									// state. Same load path as My Files.
+									return getDrawIOFromNextcloudXML(filename, nextcloudBaseUrl + '/remote.php/dav/files/' + encodeURIComponent(nextcloudUsername) + '/', null, nextcloudPassword, '/');
+								})
+								.then(function(xml)
+								{
+									if (!xml) { throw new Error('Could not reload restored file from Nextcloud.'); }
+									editorUi.fileLoaded(new LocalFile(editorUi, xml, filename, true), true);
+									editorUi.editor.modified = false;
+									if (typeof updateNolaiFileTitle === 'function') { updateNolaiFileTitle(filename); }
+									// Re-bind the editor to the restored file so a follow-up ⌘+S
+									// goes to the same Nextcloud path. The filename hasn't changed,
+									// but fileLoaded constructs a fresh LocalFile so the binding
+									// would otherwise look "missing" until the user manually saved.
+									if (typeof nolaiSetCurrentNextcloudFile === 'function')
+									{
+										nolaiSetCurrentNextcloudFile(filename, '/');
+									}
+									editorUi.editor.setStatus('Version restored');
+									editorUi.hideDialog();
+								})
+								.catch(function(err)
+								{
+									status.innerText = 'Restore failed: ' + err.message;
+									restoreBtn.disabled = false;
+									restoreBtn.style.opacity = '1';
+								});
+						},
+						mxResources.get('cancel'),
+						'Restore'
+					);
+				};
+			}
+
+			// loadVersionsForCurrentFile — runs once both credentials and a current
+			// file are known. Resolves the fileid (404 → "save first"), lists
+			// versions, then hands off to renderVersionList.
+			function loadVersionsForCurrentFile(container)
+			{
+				var file = editorUi.getCurrentFile();
+				var filename = (file != null && typeof file.getTitle === 'function') ? file.getTitle() : null;
+
+				if (!filename)
+				{
+					showSaveFirst(container, 'No diagram is open in the editor.');
+					return;
+				}
+				if (!/\.drawio$/i.test(filename))
+				{
+					// Match Save dialog convention — only .drawio files round-trip
+					// cleanly through the Nextcloud workflow.
+					showSaveFirst(container, 'The current diagram is not yet saved as a .drawio file in Nextcloud.');
+					return;
+				}
+
+				container.innerHTML =
+					'<h2 style="margin:0 0 12px 0;color:' + nolaiColor + ';font-size:18px;border-bottom:2px solid ' + nolaiColor + ';padding-bottom:8px;">Version History</h2>' +
+					'<div style="padding:16px;color:#666;font-size:13px;">Loading versions for <strong>' + filename + '</strong>…</div>';
+
+				// WHY pass nextcloudUsername explicitly:
+				//   nextcloudBaseUrl is the bare 'https://localhost' root with no DAV path,
+				//   so buildNextcloudWebdavBaseContext cannot derive the uid from the URL
+				//   (its regex looks for /remote.php/dav/files/{uid}/). Other callers like
+				//   My Files pre-build a DAV-style URL with the uid embedded and so pass
+				//   null safely; we don't, so we must supply the uid as the username arg.
+				getFileIdFromNextcloud(filename, nextcloudBaseUrl, nextcloudUsername, nextcloudPassword, '/')
+					.then(function(fileId)
+					{
+						if (!fileId)
+						{
+							showSaveFirst(container,
+								'The file <strong>' + filename + '</strong> was not found at the root of your Nextcloud folder.');
+							return null;
+						}
+						return listFileVersionsInNextcloud(fileId, nextcloudBaseUrl, nextcloudUsername, nextcloudPassword)
+							.then(function(versions) { return { fileId: fileId, versions: versions }; });
+					})
+					.then(function(result)
+					{
+						if (!result) { return; } // showSaveFirst already rendered
+						renderVersionList(container, filename, result.fileId, result.versions);
+					})
+					.catch(function(err)
+					{
+						container.innerHTML = '';
+						var title = document.createElement('h2');
+						title.innerHTML = 'Version History';
+						title.style.cssText = 'margin:0 0 12px 0;color:' + nolaiColor + ';font-size:18px;border-bottom:2px solid ' + nolaiColor + ';padding-bottom:8px;';
+						container.appendChild(title);
+						var errBox = document.createElement('div');
+						errBox.style.cssText = 'padding:16px;background:#fdecea;border:1px solid #f44336;border-radius:6px;color:#b71c1c;font-size:13px;';
+						errBox.innerText = 'Could not load versions: ' + err.message;
+						container.appendChild(errBox);
+					});
+			}
+
+			// ---- Build the dialog shell ----
+			//
+			// We always start with the session banner attached (just like My Files)
+			// so the user can authenticate from inside the dialog if they aren't
+			// already signed in. The banner's onLoggedIn callback fires both for
+			// brand-new logins and for cached sessions, so loadVersionsForCurrentFile
+			// runs in both cases.
+			var rootDiv = document.createElement('div');
+			rootDiv.style.cssText = 'padding: 20px; font-family: Helvetica, Arial, sans-serif; color: #333;';
+
+			var preTitle = document.createElement('h2');
+			preTitle.innerHTML = 'Version History';
+			preTitle.style.cssText = 'margin:0 0 12px 0;color:' + nolaiColor + ';font-size:18px;border-bottom:2px solid ' + nolaiColor + ';padding-bottom:8px;';
+			rootDiv.appendChild(preTitle);
+
+			if (typeof attachNextcloudSessionBanner !== 'function')
+			{
+				editorUi.handleError({message: 'Nextcloud session banner is not available.'});
+				return;
+			}
+
+			var sessionReady = false;
+			attachNextcloudSessionBanner(rootDiv, nextcloudBaseUrl, function(username, appPassword)
+			{
+				nextcloudUsername = username;
+				nextcloudPassword = appPassword;
+				sessionReady = true;
+				// Replace the placeholder dialog with the real Version History UI
+				// once we have credentials. We swap content rather than reopening
+				// a new dialog so the user's "this is one continuous flow" mental
+				// model is preserved.
+				loadVersionsForCurrentFile(rootDiv);
+				// Re-show the dialog with a larger size now that we're showing
+				// the two-pane layout.
+				editorUi.hideDialog();
+				var dlg = new CustomDialog(editorUi, rootDiv, null);
+				// Hide CustomDialog's stock OK and Cancel buttons. The Version
+				// History footer has its own integrated Close + Restore row, so
+				// keeping the stock buttons would just produce a redundant
+				// "Cancel" sitting below the dialog content.
+				dlg.okButton.style.display = 'none';
+				if (dlg.cancelBtn) { dlg.cancelBtn.style.display = 'none'; }
+				editorUi.showDialog(dlg.container, 720, 500, true, false);
+			});
+
+			if (!sessionReady)
+			{
+				// User has no cached session — show the slim sign-in dialog. Once
+				// they complete login the callback above replaces it with the full
+				// Version History UI.
+				var loginDlg = new CustomDialog(editorUi, rootDiv, null);
+				loginDlg.okButton.style.display = 'none';
 				editorUi.showDialog(loginDlg.container, 450, 240, true, true);
 			}
 		});
@@ -5405,9 +6109,13 @@
 			
 			if (urlParams['noFileMenu'] != '1')
 			{
-				editorUi.menus.addMenuItems(menu, ['Save', 'My Files'], parent);
+				// ====== NOLAI - {- Frontend -} /Sprint 4/ Task 148 (Version Control) ======
+				// 'Version History' added next to Save / My Files so the in-app version
+				// control UI is reachable from every theme that exposes the File menu.
+				// ====== end of changes by SE ======
+				editorUi.menus.addMenuItems(menu, ['Save', 'Save As', 'My Files', 'Version History'], parent);
 			}
-	
+
 			if (Editor.currentTheme != 'simple' && Editor.currentTheme != 'min')
 			{
 				editorUi.menus.addMenuItems(menu, ['-',  'findReplace'], parent);
@@ -5554,8 +6262,12 @@
 					}
 					else
 					{
-						this.addMenuItems(menu, ['Save', 'My Files'], parent);
-						
+						// ====== NOLAI - {- Frontend -} /Sprint 4/ Task 148 (Version Control) ======
+						// Version History exposed in the embedded-file menu path too so the
+						// entry point is consistent regardless of how drawio is launched.
+						// ====== end of changes by SE ======
+						this.addMenuItems(menu, ['Save', 'Save As', 'My Files', 'Version History'], parent);
+
 						if (urlParams['saveAndExit'] == '1')
 						{
 							this.addMenuItems(menu, ['saveAndExit'], parent);
@@ -5697,8 +6409,9 @@
 					this.addMenuItems(menu, ['new'], parent);
 				}
 				// ======	NOLAI - {- Frontend -} /Sprint 2 & 3/ Task 98, Task 100 and Task 151	=====
+				// ======	NOLAI - {- Frontend -} /Sprint 4/ Task 148 — added 'Version History'	=====
 				menu.addSeparator(parent);
-				this.addMenuItems(menu, ['Save', 'My Files', 'share'], parent);
+				this.addMenuItems(menu, ['Save', 'Save As', 'My Files', 'Version History', 'share'], parent);
 				// ====== end of changes by SE	======
 			
 				if (file != null && file.constructor == DriveFile)

--- a/drawio app/src/main/webapp/js/diagramly/NextcloudFile.js
+++ b/drawio app/src/main/webapp/js/diagramly/NextcloudFile.js
@@ -23,6 +23,54 @@
 // ====== end of changes by SE ======
 var _nextcloudSessionCache = { username: null, password: null, baseUrl: null, displayName: null };
 
+// ====== NOLAI - {- Backend -} /Sprint 4/ Task 148 (Smart Save) ======
+//
+// _nolaiCurrentNextcloudFile — tracks which Nextcloud-resident file the editor
+// is currently bound to. Set on Save success / My Files load / Rename success /
+// Version restore. Read by the Save action's quick path so that ⌘+S can save
+// silently to the same Nextcloud path without re-prompting for a filename.
+//
+// Structure: { filename: string, remotePath: string } | null
+//   filename   — the full filename including the '.drawio' extension
+//   remotePath — DAV-relative folder; '/' means the user's DAV root.
+//
+// WHY module-level (not stored on the LocalFile instance):
+//   draw.io constructs new LocalFile objects on every load (My Files reload,
+//   Version restore replaces the live file with a fresh LocalFile, etc.).
+//   Storing the binding on the instance would silently lose it across those
+//   transitions and the next ⌘+S would regress to a "Save As" prompt.
+//   Using a module variable keeps the user's mental model — "I am currently
+//   editing <this Nextcloud file>" — stable across draw.io's internal
+//   re-construction of file objects.
+//
+// WHY in-memory rather than persisted:
+//   Same reasoning as _nextcloudSessionCache: this is session state that
+//   should reset on browser reload. Persisting could surprise users who
+//   open the app and find it bound to a file they no longer expect.
+// ====== end of changes by SE ======
+var _nolaiCurrentNextcloudFile = null;
+
+// nolaiSetCurrentNextcloudFile — records the Nextcloud filename + remotePath
+// the editor is now bound to. Pass null/empty filename to clear.
+function nolaiSetCurrentNextcloudFile(filename, remotePath) {
+    if (!filename) {
+        _nolaiCurrentNextcloudFile = null;
+        return;
+    }
+    _nolaiCurrentNextcloudFile = {
+        filename: filename,
+        remotePath: remotePath || '/',
+    };
+}
+
+function nolaiGetCurrentNextcloudFile() {
+    return _nolaiCurrentNextcloudFile;
+}
+
+function nolaiClearCurrentNextcloudFile() {
+    _nolaiCurrentNextcloudFile = null;
+}
+
 // ====== NOLAI - {- Frontend -} /Sprint 3/ Task 151 ======
 // _nolaiTopBarRefresh — optional callback registered by attachNextcloudTopBarButton.
 // When a dialog login button completes authentication it calls this so the top-bar
@@ -1313,6 +1361,7 @@ function renameFileInNextcloud(oldFilename, newFilename, nextcloudUrl, username,
 }
 
 // ====== NOLAI - {- Backend -} /Sprint 3/ Task 151 ======
+// ====== NOLAI - {- Backend -} /Sprint 4/ Task 148 — rename ⇒ save fallback ======
 // LocalFile.prototype.rename override — adds Nextcloud persistence to draw.io's in-memory rename.
 //
 // draw.io's default LocalFile.prototype.rename updates only the in-memory title; it has no
@@ -1322,9 +1371,19 @@ function renameFileInNextcloud(oldFilename, newFilename, nextcloudUrl, username,
 // The override reads baseUrl/username/password from _nextcloudSessionCache so that it works
 // without any extra wiring in Menus.js — the banner login flow already populates the cache.
 //
+// Sprint 4 addition — "rename also saves" behaviour:
+//   When the user renames a brand-new diagram that has not yet been saved to Nextcloud, the
+//   WebDAV MOVE source path doesn't exist on the server, so the server returns 404. Treating
+//   that as an error is unhelpful — what the user actually wants in that flow is "give this
+//   diagram a name and save it under that name". So when MOVE returns 404 we fall back to
+//   saveDrawIOToNextcloudXML with the editor's current XML under newTitle. This makes the
+//   rename dialog double as a "name & save" affordance for first-time saves.
+//
 // Assumptions:
 //   - Files are always saved at the root of the user's DAV folder (remotePath = '/').
 //   - _nextcloudSessionCache.baseUrl is set when the user connects via the session banner.
+//   - The fallback save uses this.ui.getFileData(true), the same XML serialisation the Save
+//     action uses — so the resulting Nextcloud file is byte-equivalent to a normal Save.
 // ====== end of changes by SE ======
 (function() {
     // Guard: LocalFile may not yet be defined if scripts load out of order.
@@ -1334,6 +1393,7 @@ function renameFileInNextcloud(oldFilename, newFilename, nextcloudUrl, username,
 
     LocalFile.prototype.rename = function(newTitle, success, error) {
         var oldTitle = this.title;
+        var self = this;
 
         // Always apply the in-memory rename so draw.io's toolbar updates immediately.
         _originalRename.call(this, newTitle, null, null);
@@ -1341,17 +1401,85 @@ function renameFileInNextcloud(oldFilename, newFilename, nextcloudUrl, username,
         var cache = _nextcloudSessionCache;
         var titleChanged = oldTitle && newTitle && oldTitle !== newTitle;
 
+        // saveUnderNewName — fallback path: PUT the current diagram XML under newTitle.
+        // Used when (a) MOVE returns 404 because the source doesn't exist on Nextcloud, or
+        // (b) there was no oldTitle to MOVE from in the first place (truly first-time save).
+        // Reads the live editor XML via this.ui.getFileData(true), exactly mirroring the
+        // existing Save action, so the resulting file is identical to what Save would write.
+        function saveUnderNewName(reasonLog) {
+            // self.ui is set by DrawioFile's constructor; getFileData serialises the current
+            // editor state to draw.io's XML format. This is the authoritative source of truth
+            // for the diagram's content — using self.data would risk writing stale content
+            // captured at file-load time before the user's edits.
+            var xml = (self.ui && typeof self.ui.getFileData === 'function')
+                ? self.ui.getFileData(true)
+                : (typeof self.getData === 'function' ? self.getData() : null);
+
+            if (xml == null) {
+                console.error('NOLAI: rename-save fallback could not access editor XML (' + reasonLog + ')');
+                if (typeof error === 'function') {
+                    error(new Error('Could not read diagram contents to save.'));
+                }
+                return;
+            }
+
+            saveDrawIOToNextcloudXML(newTitle, xml, cache.baseUrl, cache.username, cache.password, '/')
+                .then(function(saved) {
+                    if (saved) {
+                        updateNolaiFileTitle(newTitle);
+                        // Bind the editor to the just-created Nextcloud file so the next
+                        // ⌘+S is a silent save instead of another prompt.
+                        nolaiSetCurrentNextcloudFile(newTitle, '/');
+                        // Clear the modified flag — the editor's content is now in sync
+                        // with what was just persisted.
+                        if (self.ui && self.ui.editor) { self.ui.editor.modified = false; }
+                        // Reflect in the editor's status line so the user sees the same
+                        // confirmation they'd get from a manual Save.
+                        if (self.ui && self.ui.editor && typeof self.ui.editor.setStatus === 'function') {
+                            self.ui.editor.setStatus('Saved to Nextcloud as ' + newTitle);
+                        }
+                        if (typeof success === 'function') { success(); }
+                    } else {
+                        console.error('NOLAI: rename-save fallback PUT did not succeed (' + reasonLog + ')');
+                        if (typeof error === 'function') {
+                            error(new Error('Could not save under new name.'));
+                        }
+                    }
+                })
+                .catch(function(saveErr) {
+                    console.error('NOLAI: rename-save fallback PUT threw (' + reasonLog + ')', saveErr);
+                    if (typeof error === 'function') { error(saveErr); }
+                });
+        }
+
         if (cache.username && cache.password && cache.baseUrl && titleChanged) {
-            // Perform WebDAV MOVE then fire the caller's callbacks.
+            // Try a real MOVE first — that is the correct operation for an existing file
+            // because it preserves the Nextcloud fileid and version chain. Only fall back
+            // to a PUT if the source didn't exist (404).
             renameFileInNextcloud(oldTitle, newTitle, cache.baseUrl, cache.username, cache.password, '/')
                 .then(function() {
                     updateNolaiFileTitle(newTitle);
+                    // The current-file binding now points at the new name on the server.
+                    nolaiSetCurrentNextcloudFile(newTitle, '/');
                     if (typeof success === 'function') { success(); }
                 })
                 .catch(function(err) {
-                    console.error('NOLAI: Nextcloud rename (MOVE) failed', err);
-                    if (typeof error === 'function') { error(err); }
+                    var msg = (err && err.message) ? err.message : '';
+                    // /HTTP 404/ matches the message thrown by renameFileInNextcloud when
+                    // the WebDAV MOVE returns 404. Tightly scoped — any other failure
+                    // (auth, conflict, network) still surfaces as a real error.
+                    if (/HTTP 404/i.test(msg)) {
+                        console.warn('NOLAI: Source missing on Nextcloud — falling back to PUT save under new name.');
+                        saveUnderNewName('MOVE 404');
+                    } else {
+                        console.error('NOLAI: Nextcloud rename (MOVE) failed', err);
+                        if (typeof error === 'function') { error(err); }
+                    }
                 });
+        } else if (cache.username && cache.password && cache.baseUrl && newTitle && !oldTitle) {
+            // Edge case: no oldTitle at all (truly first-time naming). Skip the MOVE
+            // attempt and go straight to a fresh PUT under newTitle.
+            saveUnderNewName('no oldTitle');
         } else {
             // No Nextcloud session — just update the title bar and fire success.
             updateNolaiFileTitle(newTitle);
@@ -1396,3 +1524,328 @@ function updateNolaiFileTitle(filename) {
 
 // Show "Untitled" once draw.io has had time to render its toolbar (~1 s after script load).
 setTimeout(function() { updateNolaiFileTitle(null); }, 1000);
+
+// ====== NOLAI - {- Backend -} /Sprint 4/ Task 148 (Version Control) ======
+//
+// Nextcloud Versions API helpers.
+//
+// WHY this exists alongside the existing native draw.io revision history path:
+//   draw.io ships with a native RevisionDialog wired to ui.getRevisions(), which
+//   plugins/nextcloud.js implements via remoteInvoke('getFileRevisions') — a
+//   postMessage RPC that requires drawio to be embedded inside Nextcloud's
+//   parent window. In our standalone NOLAI deployment drawio runs on its own
+//   origin (https://localhost:5443) and talks to Nextcloud directly over WebDAV,
+//   so the postMessage path has no listener and revision history is broken.
+//
+//   These helpers fill that gap by talking directly to Nextcloud's Versions
+//   WebDAV endpoint, exactly the same way saveDrawIOToNextcloudXML and
+//   listDrawIOFilesInNextcloud talk to the Files endpoint. Authentication
+//   reuses the same _nextcloudSessionCache (Basic Auth via app password from
+//   Login Flow v2) so no new login flow is needed.
+//
+// API SHAPE (Nextcloud 25+):
+//   File metadata:   PROPFIND on /remote.php/dav/files/{user}/{path}/{file}
+//                    requesting <oc:fileid/> — returns the numeric file id.
+//   Version listing: PROPFIND on /remote.php/dav/versions/{user}/versions/{fileId}/
+//                    with Depth:1 — each <d:response> is one version. The href
+//                    last segment is the version's Unix-seconds timestamp.
+//   Version content: GET on the version href — body is the historical file XML.
+//   Restore:         MOVE on the version href with
+//                    Destination: /remote.php/dav/versions/{user}/restore/target
+//                    Nextcloud's DAV plugin recognises /restore/target as a
+//                    marker that means "atomically copy this version's contents
+//                    over the live file". This is the supported, idiomatic
+//                    restore path — there is no separate REST endpoint.
+//
+// All helpers return Promises that resolve to the documented value, or reject
+// with an Error containing a human-readable message. They rely on
+// buildNextcloudWebdavBaseContext for auth + URL construction so they share
+// the cookie/Basic-Auth strategy used everywhere else in this file.
+// ====== end of changes by SE ======
+
+// ====== NOLAI - {- Backend -} /Sprint 4/ Task 148 (Version Control) ======
+//
+// getFileIdFromNextcloud(filename, nextcloudUrl, username, password, remotePath)
+//
+// Resolves the Nextcloud internal file id for a file. The file id is required
+// by every other Versions endpoint — the Versions API is keyed by file id, not
+// path, so that file moves/renames do not break the version chain.
+//
+// Implementation: PROPFIND on the file with body
+//   <d:propfind xmlns:d="DAV:" xmlns:oc="http://owncloud.org/ns">
+//     <d:prop><oc:fileid/></d:prop>
+//   </d:propfind>
+// then parse the first <oc:fileid> element from the response.
+//
+// Returns a Promise resolving to the file id (string of digits) or null if the
+// file does not exist on the server (404 or empty response). Any other error
+// rejects so callers can surface useful messages.
+// ====== end of changes by SE ======
+function getFileIdFromNextcloud(filename, nextcloudUrl, username, password, remotePath) {
+    var ctx = buildNextcloudWebdavContext(filename, nextcloudUrl, username, password, remotePath || '/');
+    if (!ctx) {
+        return Promise.reject(new Error('Could not build WebDAV context'));
+    }
+
+    var headers = {
+        'Depth': '0',
+        'Content-Type': 'application/xml; charset=utf-8',
+    };
+    if (ctx.authHeader) { headers['Authorization'] = ctx.authHeader; }
+
+    // The oc: namespace is owncloud-derived and is what Nextcloud uses for fileid.
+    var body =
+        '<?xml version="1.0"?>' +
+        '<d:propfind xmlns:d="DAV:" xmlns:oc="http://owncloud.org/ns">' +
+        '<d:prop><oc:fileid/></d:prop>' +
+        '</d:propfind>';
+
+    return fetch(ctx.webdavUrl, Object.assign({}, ctx.requestBase, {
+        method: 'PROPFIND', headers: headers, body: body,
+    })).then(function(resp) {
+        // 404 = file not yet on Nextcloud → caller decides what to do (e.g. prompt save).
+        if (resp.status === 404) { return null; }
+        if (!resp.ok) {
+            throw new Error('PROPFIND for fileid failed: HTTP ' + resp.status);
+        }
+        return resp.text();
+    }).then(function(xmlText) {
+        if (xmlText == null) { return null; }
+        var parser = new DOMParser();
+        var doc = parser.parseFromString(xmlText, 'application/xml');
+        // Note: ownCloud namespace URI is used as-is by Nextcloud for backwards compat.
+        var nodes = doc.getElementsByTagNameNS('http://owncloud.org/ns', 'fileid');
+        if (nodes && nodes.length > 0 && nodes[0].textContent) {
+            return nodes[0].textContent.trim();
+        }
+        return null;
+    });
+}
+
+// ====== NOLAI - {- Backend -} /Sprint 4/ Task 148 (Version Control) ======
+//
+// listFileVersionsInNextcloud(fileId, nextcloudUrl, username, password)
+//
+// Lists every server-side version of the file identified by fileId.
+//
+// WebDAV endpoint:
+//   /remote.php/dav/versions/{user}/versions/{fileId}/
+// PROPFIND Depth:1 returns the directory itself + one <response> per version.
+//
+// Version metadata returned:
+//   versionId   — last segment of the version href (Unix seconds timestamp,
+//                 also a stable identifier the user can refer to)
+//   href        — absolute server-relative path used by GET / MOVE
+//   absUrl      — fully qualified URL (origin + href), used directly by fetch
+//   mtime       — JS milliseconds (parsed from <d:getlastmodified> RFC 1123)
+//   size        — bytes (parsed from <d:getcontentlength>) or null
+//   etag        — opaque etag string or null
+//
+// The current/live file is NOT returned by Nextcloud in this listing — only
+// the *historical* versions appear. The caller renders the live file as a
+// separate "Current" entry in the UI.
+//
+// Returns a Promise resolving to an array, sorted newest-first by mtime.
+// ====== end of changes by SE ======
+function listFileVersionsInNextcloud(fileId, nextcloudUrl, username, password) {
+    if (!fileId) {
+        return Promise.reject(new Error('Missing fileId — cannot list versions'));
+    }
+
+    // We deliberately use buildNextcloudWebdavBaseContext (NOT the per-file variant)
+    // because the versions endpoint is not under /remote.php/dav/files/, so the
+    // generic per-file URL builder would put us in the wrong place.
+    var ctx = buildNextcloudWebdavBaseContext(nextcloudUrl, username, password, '/');
+    if (!ctx) {
+        return Promise.reject(new Error('Could not build WebDAV context'));
+    }
+
+    // /remote.php/dav/versions/{user}/versions/{fileId}/
+    var versionsPath = '/remote.php/dav/versions/' + ctx.encodedUsername +
+                       '/versions/' + encodeURIComponent(fileId) + '/';
+    var versionsUrl = ctx.baseUrl + versionsPath;
+
+    var headers = {
+        'Depth': '1',
+        'Content-Type': 'application/xml; charset=utf-8',
+    };
+    if (ctx.authHeader) { headers['Authorization'] = ctx.authHeader; }
+
+    // Request the standard mtime/size/etag triple — sufficient to render
+    // a meaningful list. Author info varies across Nextcloud versions and
+    // is intentionally not requested to keep behaviour predictable.
+    var body =
+        '<?xml version="1.0"?>' +
+        '<d:propfind xmlns:d="DAV:">' +
+        '<d:prop>' +
+        '<d:getlastmodified/>' +
+        '<d:getcontentlength/>' +
+        '<d:getetag/>' +
+        '</d:prop>' +
+        '</d:propfind>';
+
+    return fetch(versionsUrl, Object.assign({}, ctx.requestBase, {
+        method: 'PROPFIND', headers: headers, body: body,
+    })).then(function(resp) {
+        // 404 = no versions stored for this file (Nextcloud keeps versions only
+        // after at least one overwrite; a brand-new file has zero versions).
+        if (resp.status === 404) { return ''; }
+        if (!resp.ok) {
+            throw new Error('PROPFIND for versions failed: HTTP ' + resp.status);
+        }
+        return resp.text();
+    }).then(function(xmlText) {
+        var versions = [];
+        if (!xmlText) { return versions; }
+
+        var parser = new DOMParser();
+        var doc = parser.parseFromString(xmlText, 'application/xml');
+        var responses = doc.getElementsByTagNameNS('DAV:', 'response');
+
+        for (var i = 0; i < responses.length; i++) {
+            var rsp = responses[i];
+            var hrefNode = rsp.getElementsByTagNameNS('DAV:', 'href')[0];
+            if (!hrefNode || !hrefNode.textContent) { continue; }
+
+            var href = hrefNode.textContent;
+            // The directory itself appears as the first <response>; skip it.
+            // It ends in "/versions/{fileId}/" while real versions end in a
+            // numeric timestamp segment with no trailing slash.
+            if (/\/versions\/[^/]+\/?$/.test(href) && /\/$/.test(href)) {
+                continue;
+            }
+
+            // Last non-empty path segment is the version id (Unix seconds).
+            var segments = href.split('/').filter(function(s) { return s.length > 0; });
+            var versionId = segments[segments.length - 1];
+            if (!versionId) { continue; }
+
+            // Parse <d:getlastmodified> (RFC 1123 string) → ms since epoch.
+            // Fall back to versionId * 1000 if Nextcloud omits the property.
+            var mtime = null;
+            var lmNodes = rsp.getElementsByTagNameNS('DAV:', 'getlastmodified');
+            if (lmNodes && lmNodes.length > 0 && lmNodes[0].textContent) {
+                var parsed = Date.parse(lmNodes[0].textContent);
+                if (!isNaN(parsed)) { mtime = parsed; }
+            }
+            if (mtime == null) {
+                var asNum = parseInt(versionId, 10);
+                if (!isNaN(asNum)) { mtime = asNum * 1000; }
+            }
+
+            var size = null;
+            var clNodes = rsp.getElementsByTagNameNS('DAV:', 'getcontentlength');
+            if (clNodes && clNodes.length > 0 && clNodes[0].textContent) {
+                var asInt = parseInt(clNodes[0].textContent, 10);
+                if (!isNaN(asInt)) { size = asInt; }
+            }
+
+            var etag = null;
+            var etagNodes = rsp.getElementsByTagNameNS('DAV:', 'getetag');
+            if (etagNodes && etagNodes.length > 0 && etagNodes[0].textContent) {
+                etag = etagNodes[0].textContent.replace(/^"|"$/g, '');
+            }
+
+            versions.push({
+                versionId: versionId,
+                href: href,
+                absUrl: ctx.baseOrigin + href,
+                mtime: mtime,
+                size: size,
+                etag: etag,
+            });
+        }
+
+        // Sort newest-first so the list reads top-to-bottom from most recent.
+        versions.sort(function(a, b) {
+            return (b.mtime || 0) - (a.mtime || 0);
+        });
+
+        return versions;
+    });
+}
+
+// ====== NOLAI - {- Backend -} /Sprint 4/ Task 148 (Version Control) ======
+//
+// getVersionContentFromNextcloud(versionAbsUrl, username, password)
+//
+// Fetches the raw XML body of a single historical version. This is the same
+// kind of content that getDrawIOFromNextcloudXML returns for the live file —
+// a draw.io <mxfile> XML document — so the result can be fed straight into
+// editorUi.fileLoaded(new LocalFile(...)) or used to populate a preview Graph.
+//
+// We construct the auth context from a base URL because the version URL is
+// fully qualified and not under /remote.php/dav/files/.
+// ====== end of changes by SE ======
+function getVersionContentFromNextcloud(versionAbsUrl, nextcloudUrl, username, password) {
+    if (!versionAbsUrl) {
+        return Promise.reject(new Error('Missing version URL'));
+    }
+    var ctx = buildNextcloudWebdavBaseContext(nextcloudUrl, username, password, '/');
+    if (!ctx) {
+        return Promise.reject(new Error('Could not build WebDAV context'));
+    }
+
+    var headers = {};
+    if (ctx.authHeader) { headers['Authorization'] = ctx.authHeader; }
+
+    return fetch(versionAbsUrl, Object.assign({}, ctx.requestBase, {
+        method: 'GET', headers: headers,
+    })).then(function(resp) {
+        if (!resp.ok) {
+            throw new Error('GET version failed: HTTP ' + resp.status);
+        }
+        return resp.text();
+    });
+}
+
+// ====== NOLAI - {- Backend -} /Sprint 4/ Task 148 (Version Control) ======
+//
+// restoreVersionInNextcloud(versionAbsUrl, nextcloudUrl, username, password)
+//
+// Atomically rolls the live file back to a chosen historical version.
+//
+// Implementation: WebDAV MOVE on the version's absolute URL with the
+// Destination header set to /remote.php/dav/versions/{user}/restore/target.
+// Nextcloud's DAV plugin recognises that path as a virtual restore marker —
+// the server overwrites the live file with the version's contents and then
+// captures the *previous* live state as a new version (so a restore is itself
+// reversible by performing another restore on the now-newest historical entry).
+//
+// WHY MOVE (and not COPY/PUT to the live file):
+//   - MOVE is the documented Nextcloud restore mechanism; it preserves the
+//     original mtime/etag chain and triggers the proper "version restored"
+//     activity entry inside Nextcloud.
+//   - PUT-ing the version contents to the live file would create an extra
+//     intermediate version and lose the link to the original entry.
+//
+// Returns a Promise resolving to true on success or rejecting with an Error.
+// ====== end of changes by SE ======
+function restoreVersionInNextcloud(versionAbsUrl, nextcloudUrl, username, password) {
+    if (!versionAbsUrl) {
+        return Promise.reject(new Error('Missing version URL'));
+    }
+    var ctx = buildNextcloudWebdavBaseContext(nextcloudUrl, username, password, '/');
+    if (!ctx) {
+        return Promise.reject(new Error('Could not build WebDAV context'));
+    }
+
+    // Destination is the virtual restore-target path under the user's versions root.
+    var destination = ctx.baseUrl +
+        '/remote.php/dav/versions/' + ctx.encodedUsername + '/restore/target';
+
+    var headers = {
+        'Destination': destination,
+        // Overwrite must be T (true) — we are explicitly replacing the live file.
+        'Overwrite': 'T',
+    };
+    if (ctx.authHeader) { headers['Authorization'] = ctx.authHeader; }
+
+    return fetch(versionAbsUrl, Object.assign({}, ctx.requestBase, {
+        method: 'MOVE', headers: headers,
+    })).then(function(resp) {
+        // 201 Created or 204 No Content both indicate success in WebDAV semantics.
+        if (resp.status === 201 || resp.status === 204) { return true; }
+        throw new Error('Version restore (MOVE) failed: HTTP ' + resp.status);
+    });
+}

--- a/tests/manual/UI_LOGO_TEST.md
+++ b/tests/manual/UI_LOGO_TEST.md
@@ -20,7 +20,7 @@ Status:  <span style="color: green">PASS</span>
 ## Test 2 – Resizing Browser Window Horizontally
 
 **Action:**
-Resize Broswser window on x-axis
+Resize Browser window on x-axis
 
 **Expected Result:**
 - Logo preserving its size
@@ -43,7 +43,7 @@ Status: <span style="color: green">PASS</span>
 ## Test 3 – Resizing Browser Window Vertically
 
 **Action:**
-Resize Broswser window on y-axis
+Resize Browser window on y-axis
 
 **Expected Result:**
 - Logo preserving its size

--- a/tests/manual/VERSION_CONTROL_TEST.md
+++ b/tests/manual/VERSION_CONTROL_TEST.md
@@ -1,0 +1,112 @@
+# Version Control UI and functionality test
+
+## Test 1 – Check if version control activates correctly
+
+**Action:**
+Load diagrams.net with the DPD plugin enabled.
+Place an object from the library into the editor and move it to the right.
+Open the File menu, authenticate if needed, and save the file as `test1.drawio`.
+Move the object to the left.
+Save the file again with the same name.
+Open the File menu and choose `Version History`.
+Check that the version list appears and select each version to verify the preview updates.
+
+**Expected Result:**
+- The Version History dialog shows 2 version entries for `test1.drawio`.
+- The file name `test1.drawio` is shown in the Version History dialog header.
+- The older version preview shows the object on the right.
+- The newer version preview shows the object on the left.
+- No console errors.
+
+**Actual Result:**
+- 
+- 
+
+Status:  <span style="color: green">PASS</span>
+
+---
+
+### Test 2 – Unsaved file / save-first flow
+**Action:**
+Open a new diagram and do not save it to Nextcloud.
+Open the File menu and choose `Version History`.
+
+**Expected Result:**
+- A friendly message appears stating the file must be saved first.
+- A button is available to save the diagram to Nextcloud.
+- The dialog does not crash or show raw errors.
+
+---
+
+### Test 3 – First save only / no historical versions
+**Action:**
+Save a new file once as `test2.drawio`.
+Open the File menu and choose `Version History`.
+
+**Expected Result:**
+- The dialog shows a message that no prior versions exist yet.
+- The message explains Nextcloud starts keeping versions after the first overwrite.
+- No console errors.
+
+---
+
+### Test 4 – Preview switching between versions
+**Action:**
+Save a file twice with two different visual states.
+Open `Version History`.
+Click the newer version, then click the older version.
+
+**Expected Result:**
+- The preview updates when each version is selected.
+- The dialog shows a loading state while fetching the preview.
+- The older and newer previews match the correct saved states.
+
+---
+
+### Test 5 – Restore version
+**Action:**
+From `Version History`, select an older version and click `Restore this version`.
+Confirm the restore prompt.
+
+**Expected Result:**
+- The restore confirmation appears.
+- The editor reloads the restored content.
+- The file name remains the same.
+- No console errors.
+- Optionally, a new version entry is created after restore and save.
+
+---
+
+### Test 6 – Login / auth fallback
+**Action:**
+Open `Version History` when not signed in to Nextcloud.
+Authenticate through the dialog.
+
+**Expected Result:**
+- The dialog shows the session/login banner first.
+- After login, it loads the version list without reopening the dialog.
+- No console errors.
+
+---
+
+### Test 7 – Non-`.drawio` file handling
+**Action:**
+Open a file in the editor that is not saved as `.drawio` (if possible).
+Open `Version History`.
+
+**Expected Result:**
+- A message is shown saying only `.drawio` files are supported for version history.
+- No console errors.
+
+---
+
+### Test 8 – Error handling
+**Action:**
+Simulate a network/auth failure while loading versions or preview content.
+Open `Version History`.
+
+**Expected Result:**
+- The dialog shows a readable error message.
+- The UI does not freeze or crash.
+- No raw stack traces are visible to the user.
+


### PR DESCRIPTION
**Summary of what is added:**
- UI for version control switching
- Ctrl + S and cmd + S now use the custom save operations that we have implemented
- Updated the renaming so that when the file is not yet saved it will save it instead of “renaming”

**How did you do it (walkthrough):**
- Created 4 new WebDAV Helpers in NextcloudFile.js 
    - getFileIdFromNextcloud — resolves the Nextcloud internal file ID via PROPFIND; returns null on 404 so callers can show 'Save first'.
    - listFileVersionsInNextcloud — fetches all versions for a file ID, sorted newest-first.
    - getVersionContentFromNextcloud — retrieves historical diagram XML for preview and restore.
    - restoreVersionInNextcloud — uses WebDAV MOVE to Nextcloud's /restore/target virtual path, preserving the version chain and making every restore reversible.
- The smart ctrl+S will do “save as” if there is no tracked file already existing and it will do “save” if the file is already tracked
- Renaming an unsaved file now falls back to PUT under the new name instead of showing an error (so the user can save the file through the rename option instead of getting a WebDAV error saying that the file is not found)

**Why did you do it like this:**
- NextcloudFile.js was edited in a way that it uses next clouds built in infrastructure for versions
- ctrl+S was done to prevent the user from accidentally being able to save to google drive or something like that
- The renaming was done so that it matches the users intent of saving the file if they are trying to rename an unnamed file.
