### PR TITLE
Disable themes

### DIFF
--- a/drawio app/src/main/webapp/js/diagramly/App.js
+++ b/drawio app/src/main/webapp/js/diagramly/App.js
@@ -1866,29 +1866,13 @@ App.prototype.init = function()
 		{
 			this.setCompactMode(true);
 		}
-		// ======	NOLAI - Frontend/Sprint 1/ Task #89	=====
-		if (Editor.currentTheme == 'atlas' || urlParams['atlas'] == '1')
-		{	
-			this.icon = document.createElement('img');
 
-			// NOLAI - Sprint 1 - Change site logo to nolai logo
-			this.icon.setAttribute('src', IMAGE_PATH + '/NOLAI_logo.png');
-
-			this.icon.setAttribute('title', mxResources.get('draw.io'));
-			this.icon.className = 'geSmallAppIcon';
-			// this.icon.style.padding = '0 4px 0 0';
-
-			if (urlParams['embed'] != '1')
-			{
-				this.icon.style.cursor = 'pointer';
-				
-				mxEvent.addListener(this.icon, 'click', mxUtils.bind(this, function(evt)
-				{
-					this.appIconClicked(evt);
-				}));
-			}
-			
-			this.menubar.container.insertBefore(this.icon, this.menubar.container.firstChild);
+		// ======	NOLAI - Frontend/Sprint 4/ Task #196	=====
+		// Force the correct theme to be used
+		if (Editor.currentTheme != 'kennedy')
+		{
+			console.log("Forcing 'Kennedy' theme");
+			Editor.currentTheme = 'kennedy';
 		}
 		// ====== end of changes by SE	======
 	}

--- a/drawio app/src/main/webapp/js/diagramly/Menus.js
+++ b/drawio app/src/main/webapp/js/diagramly/Menus.js
@@ -4287,56 +4287,56 @@
 			editorUi.userPanel.style.top = '10px';
 		});
 
-		this.put('theme', new Menu(mxUtils.bind(this, function(menu, parent)
-		{
-			var theme = (urlParams['sketch'] == '1') ? 'sketch' : mxSettings.getUi();
+		// this.put('theme', new Menu(mxUtils.bind(this, function(menu, parent)
+		// {
+		// 	var theme = (urlParams['sketch'] == '1') ? 'sketch' : mxSettings.getUi();
 			
-			var autoItem = menu.addItem(mxResources.get('automatic'), null, function()
-			{
-				editorUi.setCurrentTheme('');
-			}, parent);
+		// 	var autoItem = menu.addItem(mxResources.get('automatic'), null, function()
+		// 	{
+		// 		editorUi.setCurrentTheme('');
+		// 	}, parent);
 			
-			var item = menu.addItem(mxResources.get('classic'), null, function()
-			{
-				editorUi.setCurrentTheme('kennedy');
-			}, parent);
+		// 	var item = menu.addItem(mxResources.get('classic'), null, function()
+		// 	{
+		// 		editorUi.setCurrentTheme('kennedy');
+		// 	}, parent);
 
-			var themeFound = false;
+		// 	var themeFound = false;
 
-			if (theme == 'kennedy' || theme == 'dark')
-			{
-				menu.addCheckmark(item, Editor.checkmarkImage);
-				themeFound = true;
-			}
+		// 	if (theme == 'kennedy' || theme == 'dark')
+		// 	{
+		// 		menu.addCheckmark(item, Editor.checkmarkImage);
+		// 		themeFound = true;
+		// 	}
 
-			for (var i = 0; i < Editor.themes.length; i++)
-			{
-				(mxUtils.bind(this, function(key)
-				{
-					item = menu.addItem(mxResources.get((key == 'min') ?
-						'minimal' : key), null, function()
-					{
-						editorUi.setCurrentTheme(key);
-					}, parent);
+		// 	for (var i = 0; i < Editor.themes.length; i++)
+		// 	{
+		// 		(mxUtils.bind(this, function(key)
+		// 		{
+		// 			item = menu.addItem(mxResources.get((key == 'min') ?
+		// 				'minimal' : key), null, function()
+		// 			{
+		// 				editorUi.setCurrentTheme(key);
+		// 			}, parent);
 
-					if (theme == key)
-					{
-						menu.addCheckmark(item, Editor.checkmarkImage);
-						themeFound = true;
-					}
+		// 			if (theme == key)
+		// 			{
+		// 				menu.addCheckmark(item, Editor.checkmarkImage);
+		// 				themeFound = true;
+		// 			}
 					
-					if (key == 'simple')
-					{
-						menu.addSeparator(parent);
-					}
-				})(Editor.themes[i]));
-			}
+		// 			if (key == 'simple')
+		// 			{
+		// 				menu.addSeparator(parent);
+		// 			}
+		// 		})(Editor.themes[i]));
+		// 	}
 			
-			if (!themeFound)
-			{
-				menu.addCheckmark(autoItem, Editor.checkmarkImage);
-			}
-		})));
+		// 	if (!themeFound)
+		// 	{
+		// 		menu.addCheckmark(autoItem, Editor.checkmarkImage);
+		// 	}
+		// })));
 
 		var renameAction = this.editorUi.actions.addAction('rename...', mxUtils.bind(this, function()
 		{

--- a/tests/manual/DISABLE_THEMES_TEST.md
+++ b/tests/manual/DISABLE_THEMES_TEST.md
@@ -1,0 +1,42 @@
+## Test 1 – Removed features
+
+**Action:**
+Click on the 'extras' button in the menus bar and look at the features
+
+**Expected Result:**
+- All unnecessary features are removed
+
+**Actual Result:**
+
+Status: PASSED
+
+---
+
+## Test 2 – Kennedy theme
+
+**Action:**
+Take a look at the layout and style of the webpage
+
+**Expected Result:**
+- The Kennedy theme is used
+
+**Actual Result:**
+
+Status: PASSED
+
+---
+
+## Test 3 – Forcing Kennedy theme
+
+**Action:**
+Save a file and load it with the 'My Files' option
+
+**Expected Result:**
+- The Kennedy theme is always forced to be used
+
+**Actual Result:**
+
+Status: PASSED
+
+---
+


### PR DESCRIPTION
### What:

- Disabled unnecessary options (theme menu)
- Forced the Kennedy theme to be in use all time
- Added manual testing of these actions

### How:

- By removing the code of the unwanted options and setting the theme to the Kennedy theme if this isn't the theme already

### Why:

- Because we don't want unnecessary options 
- And we always use the Kennedy theme and no other themes. 



