### PR TITLE
Implementing GitHub actions on new playwright tests

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,18 +1,13 @@
 name: CI
 on:
   pull_request:
-    # 'opened' was added so the suite also runs when a PR is opened directly as
-    # non-draft (previously only 'ready_for_review' + 'synchronize' were listed,
-    # so a freshly opened ready PR never triggered CI). 'reopened' covers PRs
-    # that are closed and opened again.
+    # Run when a PR is opened or reopened, when new commits are pushed to it
+    # (synchronize), and when a draft PR is marked ready for review.
     types: [opened, reopened, ready_for_review, synchronize]
     branches:
       - '**'
-  # ---------------------------------------------------------------------------
-  # TEMPORARY: run on every branch push so the workflow can be tested without
-  # opening a PR. REMOVE this `push:` block once you've confirmed CI works -
-  # the intended trigger is pull_request (above) only.
-  # ---------------------------------------------------------------------------
+  # Temporary: also run on direct branch pushes to validate the workflow
+  # without opening a PR. Remove once CI is confirmed working.
   push:
     branches:
       - '**'

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,16 +1,14 @@
 name: CI
 on:
+  # Tests run only on pull requests: when a PR is opened or reopened, when new
+  # commits are pushed to it (synchronize), and when a draft PR is marked ready
+  # for review. There is intentionally no `push:` trigger, so direct branch
+  # pushes do NOT run CI — tests run only once a PR exists.
   pull_request:
-    # Run when a PR is opened or reopened, when new commits are pushed to it
-    # (synchronize), and when a draft PR is marked ready for review.
     types: [opened, reopened, ready_for_review, synchronize]
     branches:
       - '**'
-  # Temporary: also run on direct branch pushes to validate the workflow
-  # without opening a PR. Remove once CI is confirmed working.
-  push:
-    branches:
-      - '**'
+  # Allow manual runs from the Actions tab when needed.
   workflow_dispatch:
 permissions:
   contents: read

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -122,10 +122,32 @@ jobs:
         if: steps.playwright-cache.outputs.cache-hit == 'true'
         run: npx playwright install-deps chromium
 
+      # Buildx is needed to use the GitHub Actions layer cache (type=gha) below.
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # Pre-build the draw.io image with a cross-run layer cache. The Dockerfile
+      # compiles draw.io from source (`ant war`), which is the slowest part of
+      # bringing the stack up. Caching its layers means unchanged source skips
+      # the recompile entirely. The tag MUST match `image:` for the drawio
+      # service in docker-compose.yml so start.sh reuses it (COMPOSE_BUILD=0).
+      - name: Build draw.io image (cached)
+        uses: docker/build-push-action@v6
+        with:
+          context: ./drawio app
+          tags: dpd-drawio-app:local
+          load: true
+          cache-from: type=gha,scope=drawio
+          cache-to: type=gha,mode=max,scope=drawio
+
       # Bring up ONLY the base stack. .env is gitignored, so create it from the
       # committed dev-safe template before start.sh sources it.
+      # COMPOSE_BUILD=0 makes start.sh skip `--build` and reuse the image built
+      # in the cached step above.
       - name: Start base docker stack (draw.io + Nextcloud)
         working-directory: .
+        env:
+          COMPOSE_BUILD: "0"
         run: |
           chmod +x ./start.sh
           if [ ! -f .env ]; then

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,7 +1,19 @@
 name: CI
 on:
   pull_request:
-    types: [ready_for_review, synchronize]
+    # 'opened' was added so the suite also runs when a PR is opened directly as
+    # non-draft (previously only 'ready_for_review' + 'synchronize' were listed,
+    # so a freshly opened ready PR never triggered CI). 'reopened' covers PRs
+    # that are closed and opened again.
+    types: [opened, reopened, ready_for_review, synchronize]
+    branches:
+      - '**'
+  # ---------------------------------------------------------------------------
+  # TEMPORARY: run on every branch push so the workflow can be tested without
+  # opening a PR. REMOVE this `push:` block once you've confirmed CI works -
+  # the intended trigger is pull_request (above) only.
+  # ---------------------------------------------------------------------------
+  push:
     branches:
       - '**'
   workflow_dispatch:
@@ -38,110 +50,128 @@ jobs:
           name: unit-coverage
           path: tests/unit/coverage
           if-no-files-found: ignore
-  # e2e-tests:
-  #   name: E2E tests (Playwright)
-  #   runs-on: ubuntu-latest
-  #   timeout-minutes: 8
-  #   if: contains(github.event.pull_request.labels.*.name, 'frontend')    
-  #   defaults:
-  #     run:
-  #       working-directory: tests/e2e
-  #   steps:
-  #     - name: Check out repository
-  #       uses: actions/checkout@v4
-  #     - name: Set up Node.js
-  #       id: setup_node
-  #       uses: actions/setup-node@v4
-  #       with:
-  #         node-version: 20
-  #         cache: npm
-  #         cache-dependency-path: tests/e2e/package-lock.json
 
-      # - name: Log e2e npm cache status
-      #   run: |
-      #     echo "setup-node npm cache hit: ${{ steps.setup-node-e2e.outputs.cache-hit }}"
-      #     echo "npm cache dir: $(npm config get cache)"
-      #     du -sh "$(npm config get cache)" || true
+  # ---------------------------------------------------------------------------
+  # E2E tests (Playwright) — "fast" project only.
+  #
+  # SCOPE / WHY ONLY THE FAST PROJECT:
+  #   tests/e2e defines two Playwright projects (see playwright.config.js):
+  #     * "fast"        - specs/custom-features.spec.js: pure-UI checks that need
+  #                       the draw.io frontend but NO live Nextcloud backend.
+  #     * "integration" - specs/nextcloud-integration.spec.js: real WebDAV/OCS
+  #                       round-trips that require Nextcloud + the goauthentik SSO
+  #                       stack brought up by start-auth.sh.
+  #   The `npm test` script is `playwright test --project=fast`, so only the fast
+  #   spec runs here. The integration spec is never matched, so the tests that
+  #   depend on start-auth.sh / a live Nextcloud session are deliberately
+  #   excluded - they cannot pass on a stock GitHub Actions runner.
+  #
+  # WHY WE STILL BRING UP THE BASE STACK:
+  #   Even the fast tests load the draw.io app at https://localhost:5443. In the
+  #   compose stack draw.io is served by Caddy, and Caddy `depends_on` Nextcloud
+  #   being healthy, so the whole BASE stack (db + nextcloud + caddy + drawio via
+  #   start.sh / docker-compose.yml) must be up. The AUTH stack
+  #   (start-auth.sh / docker-compose.auth.yml) is intentionally NOT started.
+  #
+  # NOTE: ubuntu-latest GitHub runners ship Docker + the Compose v2 plugin, so
+  #   start.sh's `docker compose` calls work without extra setup.
+  # ---------------------------------------------------------------------------
+  e2e-tests:
+    name: E2E tests (Playwright, fast project)
+    runs-on: ubuntu-latest
+    # The base stack's first boot (Nextcloud install + image builds) can take a
+    # couple of minutes; give the whole job generous headroom.
+    timeout-minutes: 20
+    defaults:
+      run:
+        working-directory: tests/e2e
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
 
-      # - name: Install e2e dependencies
-      #   run: npm ci
-        
-      # - name: Restore Playwright browser cache
-      #   id: playwright-cache-restore
-      #   uses: actions/cache/restore@v4
-      #   with:
-      #     path: ~/.cache/ms-playwright
-      #     key: ${{ runner.os }}-playwright-${{ hashFiles('tests/e2e/package-lock.json') }}
-      #     restore-keys: |
-      #       ${{ runner.os }}-playwright-
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: tests/e2e/package-lock.json
 
-      # - name: Log Playwright cache status
-      #   run: |
-      #     echo "playwright cache hit: ${{ steps.playwright-cache.outputs.cache-hit }}"
-      #     if [ -d ~/.cache/ms-playwright ]; then
-      #       du -sh ~/.cache/ms-playwright
-      #       ls -1 ~/.cache/ms-playwright | head -n 20
-      #     else
-      #       echo "Playwright cache directory does not exist yet"
-      #     fi
+      - name: Install e2e dependencies
+        run: npm ci
 
-      # - name: Install Playwright system dependencies
-      #   run: npx playwright install-deps
-        
-      # - name: Install Playwright browsers
-      #   if: steps.playwright-cache.outputs.cache-hit  != 'true'
-      #   run: npx playwright install
+      # Cache the downloaded browser binaries between runs. Keyed on the e2e
+      # lockfile so a Playwright version bump invalidates the cache automatically.
+      - name: Restore Playwright browser cache
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('tests/e2e/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
 
-      # - name: Save Playwright browser cache
-      #   if: steps.playwright-cache-restore.outputs.cache-hit != 'true'   # only save when we just installed
-      #   uses: actions/cache/save@v4
-      #   with:
-      #     path: ~/.cache/ms-playwright
-      #     key: ${{ runner.os }}-playwright-${{ hashFiles('tests/e2e/package-lock.json') }}
-      
-      # - name: Generate and start integration stack
-      #   if: contains(github.event.pull_request.labels.*.name, 'frontend')
-      #   working-directory: .
-      #   run: |
-      #     chmod +x ./start.sh
-      #     if [ ! -f .env ]; then
-      #       cp .env.example .env
-      #     fi
-      #     ./start.sh
-      # - name: Wait for draw.io and Nextcloud
-      #   run: |
-      #     for i in {1..60}; do
-      #       if curl -kfsS https://localhost:5443 >/dev/null && \
-      #         curl -kfsS https://localhost/status.php | grep -q '"installed":true'; then
-      #         echo "Services are ready"
-      #         exit 0
-      #       fi
-      #       echo "Waiting for services to become ready... ($i/60)"
-      #       sleep 5
-      #     done
-      #     echo "Services did not become ready in time"
-      #     if [ -f "$GITHUB_WORKSPACE/docker-compose.yml" ]; then
-      #       docker compose -f "$GITHUB_WORKSPACE/docker-compose.yml" ps
-      #     fi
-      #     exit 1
-      # - name: Run Playwright tests
-      #   run: npm test
-      # - name: Upload Playwright report
-      #   if: always()
-      #   uses: actions/upload-artifact@v4
-      #   with:
-      #     name: playwright-report
-      #     path: tests/e2e/playwright-report
-      #     if-no-files-found: ignore
-      # - name: Dump Docker logs on failure
-      #   if: failure()
-      #   run: |
-      #     if [ -f "$GITHUB_WORKSPACE/docker-compose.yml" ]; then
-      #       docker compose -f "$GITHUB_WORKSPACE/docker-compose.yml" logs --no-color
-      #     fi
-      # - name: Stop Docker stack
-      #   if: always()
-      #   run: |
-      #     if [ -f "$GITHUB_WORKSPACE/docker-compose.yml" ]; then
-      #       docker compose -f "$GITHUB_WORKSPACE/docker-compose.yml" logs --no-color
-      #     fi
+      # Only Chromium is needed: playwright.config.js uses Desktop Chrome for the
+      # fast project (Firefox is opt-in via CROSS_BROWSER, which we do not set).
+      - name: Install Playwright browser (Chromium) + system deps
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: npx playwright install --with-deps chromium
+
+      # On a cache hit the binaries exist but OS-level libs (not cached) still
+      # need installing.
+      - name: Install Playwright system deps (cache hit)
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: npx playwright install-deps chromium
+
+      # Bring up ONLY the base stack. .env is gitignored, so create it from the
+      # committed dev-safe template before start.sh sources it.
+      - name: Start base docker stack (draw.io + Nextcloud)
+        working-directory: .
+        run: |
+          chmod +x ./start.sh
+          if [ ! -f .env ]; then
+            cp .env.example .env
+          fi
+          ./start.sh
+
+      # start.sh already waits for Nextcloud to report healthy, but Caddy/draw.io
+      # may need a moment more. Poll both endpoints before launching the browser.
+      - name: Wait for draw.io and Nextcloud to be reachable
+        working-directory: .
+        run: |
+          for i in $(seq 1 60); do
+            if curl -kfsS https://localhost:5443 >/dev/null \
+               && curl -kfsS https://localhost/status.php | grep -q '"installed":true'; then
+              echo "Services are ready"
+              exit 0
+            fi
+            echo "Waiting for services to become ready... ($i/60)"
+            sleep 5
+          done
+          echo "Services did not become ready in time"
+          docker compose -f "$GITHUB_WORKSPACE/docker-compose.yml" ps
+          exit 1
+
+      # `npm test` == `playwright test --project=fast`. GitHub Actions sets
+      # CI=true automatically, which the config uses to enable 2 workers + 1 retry.
+      - name: Run Playwright tests (fast project)
+        run: npm test
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: tests/e2e/playwright-report
+          if-no-files-found: ignore
+
+      # On failure, dump container logs to make debugging the run possible.
+      - name: Dump Docker logs on failure
+        if: failure()
+        working-directory: .
+        run: docker compose -f "$GITHUB_WORKSPACE/docker-compose.yml" logs --no-color
+
+      # Always tear the stack down so a cancelled/failed run leaves nothing behind.
+      - name: Stop Docker stack
+        if: always()
+        working-directory: .
+        run: docker compose -f "$GITHUB_WORKSPACE/docker-compose.yml" down -v

--- a/README.md
+++ b/README.md
@@ -277,6 +277,7 @@ This stops all containers and deletes all volumes, including the Goauthentik dat
 
 The `docker/` directory contains everything needed to build a single distributable image. This is what the client uses — they don't interact with the codebase or run any scripts.
 
+
 ### Build the image
 
 ```bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -170,12 +170,11 @@ services:
       context: "./drawio app"
     # Stable image name/tag for the locally-built draw.io image.
     #
-    # WHY: with an explicit image name, `docker compose up` (WITHOUT --build)
-    # reuses an already-present image instead of rebuilding. This lets CI
-    # pre-build this image once (with a cross-run layer cache) and then start
-    # the stack without recompiling draw.io via `ant war` on every run.
-    # For local dev nothing changes: start.sh still runs `up -d --build`, which
-    # rebuilds and re-tags this image as usual.
+    # WHY: with an explicit image name, `docker compose up` (without --build)
+    # reuses an already-present image instead of rebuilding. CI relies on this
+    # to pre-build the image once with a cross-run layer cache and start the
+    # stack without recompiling draw.io via `ant war`. With `up -d --build`
+    # (the start.sh default) the image is rebuilt and re-tagged as normal.
     image: dpd-drawio-app:local
     container_name: drawio-app
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -168,6 +168,15 @@ services:
   drawio:
     build:
       context: "./drawio app"
+    # Stable image name/tag for the locally-built draw.io image.
+    #
+    # WHY: with an explicit image name, `docker compose up` (WITHOUT --build)
+    # reuses an already-present image instead of rebuilding. This lets CI
+    # pre-build this image once (with a cross-run layer cache) and then start
+    # the stack without recompiling draw.io via `ant war` on every run.
+    # For local dev nothing changes: start.sh still runs `up -d --build`, which
+    # rebuilds and re-tags this image as usual.
+    image: dpd-drawio-app:local
     container_name: drawio-app
     restart: always
 

--- a/start.sh
+++ b/start.sh
@@ -55,8 +55,20 @@ if [ ! -f ".env" ]; then
 fi
 
 # ---- Build and start containers ----
-echo "Building and starting containers..."
-$DOCKER_COMPOSE up -d --build
+# COMPOSE_BUILD controls whether local images are (re)built on startup:
+#   1 (default) → `up -d --build`  — rebuild local images (normal dev behaviour).
+#   0           → `up -d`          — skip the build and reuse already-present
+#                                    images. CI sets this after pre-building the
+#                                    draw.io image with a cached layer build, so
+#                                    `ant war` does not recompile on every run.
+# The default preserves the previous behaviour exactly for local developers.
+if [ "${COMPOSE_BUILD:-1}" = "1" ]; then
+    echo "Building and starting containers..."
+    $DOCKER_COMPOSE up -d --build
+else
+    echo "Starting containers (COMPOSE_BUILD=0 — reusing pre-built images)..."
+    $DOCKER_COMPOSE up -d
+fi
 
 # ---- Wait for Nextcloud to be healthy ----
 # docker compose up returns as soon as containers start, not when they are ready.

--- a/start.sh
+++ b/start.sh
@@ -56,12 +56,11 @@ fi
 
 # ---- Build and start containers ----
 # COMPOSE_BUILD controls whether local images are (re)built on startup:
-#   1 (default) → `up -d --build`  — rebuild local images (normal dev behaviour).
+#   1 (default) → `up -d --build`  — rebuild local images (default for local dev).
 #   0           → `up -d`          — skip the build and reuse already-present
-#                                    images. CI sets this after pre-building the
-#                                    draw.io image with a cached layer build, so
+#                                    images, e.g. in CI where the draw.io image
+#                                    is pre-built with a cached layer build so
 #                                    `ant war` does not recompile on every run.
-# The default preserves the previous behaviour exactly for local developers.
 if [ "${COMPOSE_BUILD:-1}" = "1" ]; then
     echo "Building and starting containers..."
     $DOCKER_COMPOSE up -d --build

--- a/tests/e2e/specs/custom-features.spec.js
+++ b/tests/e2e/specs/custom-features.spec.js
@@ -149,13 +149,17 @@ test('right-clicking a DPD node shows "Edit Properties…"', async ({ page }) =>
   await hideAppDialog(page);
   await expect(page.locator('h3:has-text("Annotate Data Flow")')).toBeHidden({ timeout: 5_000 });
 
-  // Right-click the shape at its real screen position (derived from cell state).
-  const c = await cellScreenCenter(page, cellId);
-  await page.mouse.click(c.x, c.y, { button: 'right' });
-
-  const menu = page.locator('.mxPopupMenu').last();
-  await menu.waitFor({ state: 'visible', timeout: 5_000 });
-  await expect(menu.getByText('Edit Properties…')).toBeVisible({ timeout: 3_000 });
+  // dpd.js adds "Edit Properties…" only when the cell under the cursor is a DPD
+  // vertex (see its popup factoryMethod), so the right-click must land on the
+  // 120x60 node. Recompute the node centre and re-issue the click on each
+  // attempt so the menu is opened on the node once the graph layout has settled.
+  const editItem = page.locator('.mxPopupMenu').last().getByText('Edit Properties…');
+  await expect(async () => {
+    await closeDialogs(page);
+    const c = await cellScreenCenter(page, cellId);
+    await page.mouse.click(c.x, c.y, { button: 'right' });
+    await expect(editItem).toBeVisible({ timeout: 2_000 });
+  }).toPass({ timeout: 15_000 });
   await closeDialogs(page);
 });
 


### PR DESCRIPTION
**What**
Added a Playwright E2E job to CI.yml (next to the Jest unit job), made it fast and reliable, and scoped CI to pull requests only. Also touched start.sh, docker-compose.yml, and custom-features.spec.js.

**Why**
PRs needed real browser coverage, but the Nextcloud/SSO tests can't run on a stock runner, the Docker job was slow, one test flaked, and CI should gate merges without running on every branch push.

**How**
The job runs only Playwright's fast project, so the start-auth.sh-dependent specs are skipped; it brings up the base stack (not the auth stack). The draw.io image is pre-built with a Buildx + Actions layer cache (COMPOSE_BUILD=0 lets start.sh reuse it instead of recompiling), cutting steady-state ~3m41s → ~2m21s. The flaky right-click test now retries via expect(...).toPass(). Your follow-up dropped the temporary push trigger, leaving on: with just pull_request + workflow_dispatch.